### PR TITLE
feat: AI job evaluator, resume builder overhaul, and profile management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,227 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Portfolio & Resume Builder
+
+A personal portfolio management system and AI-powered resume builder — similar in concept to tools like **FlowCV**, **Reactive Resume**, and **Enhancv**, but self-hosted and fully under your own control.
+
+Manage your professional profile, curate your work history, and generate tailored resumes for specific job postings — with AI evaluation that tells you exactly how well you match a role and what to improve.
+
+---
+
+## What It Does
+
+### Portfolio Management
+
+Maintain a single source of truth for your professional identity:
+
+- **Profile** — name, title, location, contact info, LinkedIn, GitHub, website, and a professional summary
+- **Experience** — work history with rich text descriptions, employment type, and date ranges
+- **Education** — degrees, institutions, and study periods
+- **Skills** — categorised skills with optional proficiency levels
+- **Projects** — portfolio projects with tags, live URLs, and GitHub links
+- **Media** — profile image and CV upload via Supabase Storage
+
+### Resume Builder
+
+Create multiple tailored resumes from your single profile:
+
+- Pick which experiences, educations, and skills to include per resume
+- Override personal details and summary text per resume without changing your profile
+- Add resume-only custom entries that don't affect your master profile
+- Live A4 preview with smart page-break logic — sections never orphan across pages
+- Download as PDF via browser print (A4, correct margins, light mode forced)
+- Multiple resumes for different roles, all maintained from one profile
+
+### AI Job Evaluator
+
+Paste a job description, choose an AI provider, and get back:
+
+- **Match percentage** — realistic score of how well your profile fits the role
+- **Strengths** — what you already bring that's relevant
+- **Gaps** — what's missing from your profile for this role
+- **Recommendations** — specific actions to improve your candidacy
+- **Suggested resume** — automatically selects the most relevant experiences, education, and skills from your profile and writes a tailored summary
+- **Suggested new skills** — skills to learn that would improve your fit
+
+The AI response is saved directly into the resume so you can revisit insights without re-running the evaluation.
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+| --- | --- |
+| Framework | [Next.js 16](https://nextjs.org) (App Router, Server Actions) |
+| Language | TypeScript 5 |
+| UI | [shadcn/ui](https://ui.shadcn.com) + [Radix UI](https://www.radix-ui.com) + [Tailwind CSS v4](https://tailwindcss.com) |
+| Rich Text | [Tiptap](https://tiptap.dev) (bold, italic, underline, lists) |
+| Database | [MongoDB](https://www.mongodb.com) via [Prisma ORM](https://www.prisma.io) |
+| Auth | [Clerk](https://clerk.com) (restricted to a single admin email via `.env`) |
+| File Storage | [Supabase Storage](https://supabase.com/storage) (profile images, CV uploads) |
+| AI / LLM | [Vercel AI SDK](https://sdk.vercel.ai) with multi-provider support |
+| AI Providers | OpenAI GPT-4o · Anthropic Claude · Google Gemini (or via [OpenRouter](https://openrouter.ai)) |
+| Animation | [Framer Motion](https://www.framer.com/motion) |
+| Forms | [React Hook Form](https://react-hook-form.com) + [Zod](https://zod.dev) |
+| Dates | [date-fns](https://date-fns.org) |
+| Notifications | [Sonner](https://sonner.emilkowal.ski) |
+
+---
+
+## Project Structure
+
+```text
+app/
+  page.tsx                     # Public portfolio landing page
+  dashboard/
+    profile/                   # Edit personal info, headline, links
+    experience/                # Manage work history
+    education/                 # Manage education entries
+    skills/                    # Manage skills
+    projects/                  # Manage portfolio projects
+    resumes/
+      [id]/                    # Resume editor + live A4 preview
+    job-evaluator/             # AI job fit analysis + resume generation
+
+actions/                       # Next.js Server Actions (CRUD + AI)
+lib/
+  ai-providers.ts              # OpenAI / Anthropic / Google / OpenRouter routing
+  ai-prompts.ts                # Structured prompts for job evaluation
+  validation.ts                # Zod schemas shared across client and server
+prisma/
+  schema.prisma                # MongoDB schema (single-user, flat models)
+components/
+  ui/                          # shadcn/ui component library
+  app-sidebar.tsx              # Dashboard navigation
+providers/
+  theme-provider.tsx           # Light / dark mode toggle
+```
+
+---
+
+## Data Model
+
+All models are flat — no relational joins. A `Resume` stores arrays of IDs pointing to `Experience`, `Education`, and `Skill` records, plus a `content` JSON blob for per-resume overrides and cached AI evaluation results.
+
+```text
+Profile        — one record, your professional identity
+Experience[]   — work history entries (reused across resumes)
+Education[]    — education entries (reused across resumes)
+Skill[]        — skills (reused across resumes)
+Project[]      — portfolio projects (shown on public page)
+Resume[]       — each resume = selected IDs + content overrides + AI insights
+```
+
+---
+
+## AI Setup
+
+The evaluator supports three providers. You only need one key to get started.
+
+Add your keys to `.env.local`:
+
+```env
+# OpenAI (direct) or OpenRouter (prefix: sk-or-)
+OPENAI_API_KEY=sk-...
+
+# Anthropic (direct)
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Google Gemini (direct)
+GOOGLE_GENERATIVE_AI_API_KEY=AIza...
+```
+
+**OpenRouter** — if your `OPENAI_API_KEY` starts with `sk-or-`, all providers are automatically routed through [openrouter.ai](https://openrouter.ai), which lets you access GPT-4o-mini, Claude 3 Haiku, and Gemini 2.0 Flash with a single API key and pay-per-use pricing.
+
+---
 
 ## Getting Started
 
-First, run the development server:
+### Prerequisites
+
+- Node.js 18+
+- MongoDB database (local or [Atlas](https://www.mongodb.com/atlas))
+- A Clerk account (for authentication)
+- At least one AI provider key
+
+### 1. Install dependencies
+
+```bash
+npm install
+```
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env.local
+```
+
+Fill in `.env.local`:
+
+```env
+DATABASE_URL=mongodb+srv://...
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_...
+CLERK_SECRET_KEY=sk_...
+NEXT_PUBLIC_SUPABASE_URL=https://...supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
+OPENAI_API_KEY=sk-...
+ALLOWED_ADMIN_EMAIL=you@example.com
+```
+
+> `ALLOWED_ADMIN_EMAIL` locks the dashboard to your email only. Anyone else hitting `/dashboard` is redirected to the public portfolio page.
+
+### 3. Generate Prisma client
+
+```bash
+npx prisma generate
+```
+
+### 4. (Optional) Seed sample data
+
+```bash
+npm run db:seed
+```
+
+### 5. Run the development server
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) — the public portfolio page.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+Open [http://localhost:3000/dashboard](http://localhost:3000/dashboard) — the admin dashboard.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+---
 
-## Learn More
+## Resume PDF Export
 
-To learn more about Next.js, take a look at the following resources:
+The resume editor includes a live A4 preview at 82% scale. To download as PDF:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+1. Click **Download PDF** in the editor toolbar
+2. In the browser print dialog, select **Save as PDF**
+3. Set paper size to **A4**, margins to **None** (margins are handled by the app)
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+The print stylesheet forces light mode, correct A4 dimensions (794 × 1123 px at 96 dpi), and hides all dashboard UI (sidebar, header, theme toggle).
 
-## Deploy on Vercel
+---
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Deployment
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+The easiest way to deploy is [Vercel](https://vercel.com):
+
+```bash
+vercel --prod
+```
+
+Set all environment variables from `.env.local` in your Vercel project settings. The `postinstall` script runs `prisma generate` automatically on every deploy.
+
+---
+
+## Similar Projects
+
+| Project | Difference |
+| --- | --- |
+| [FlowCV](https://flowcv.com) | Cloud SaaS, not self-hosted, no AI evaluator |
+| [Reactive Resume](https://rxresu.me) | Open source, no AI job matching |
+| [Enhancv](https://enhancv.com) | Paid SaaS, AI-assisted but no profile CMS |
+| [Resume.io](https://resume.io) | Paid SaaS, template-focused |
+
+This project gives you the full pipeline: **profile CMS → resume builder → AI job evaluator → tailored PDF** — all in one self-hosted app with your own AI keys.

--- a/actions/profile.action.ts
+++ b/actions/profile.action.ts
@@ -2,38 +2,12 @@
 
 import prisma from "@/prisma/client";
 import { revalidatePath } from "next/cache";
-import { auth, currentUser } from "@clerk/nextjs/server";
-import { redirect } from "next/navigation";
 import { profileSchema, TProfile } from "@/lib/validation";
-
-export const ensureUserProfile = async () => {
-  const user = await currentUser();
-  if (!user) redirect("/sign-in");
-
-  let profile = await prisma.userProfile.findUnique({
-    where: { userId: user.id },
-  });
-
-  if (!profile) {
-    const email = user.emailAddresses[0]?.emailAddress ?? "";
-    const fullName = `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim();
-
-    profile = await prisma.userProfile.create({
-      data: {
-        userId: user.id,
-        email,
-        fullName,
-      },
-    });
-  }
-
-  return profile;
-};
 
 // Public getter for main page (no auth required)
 export const getPublicProfile = async () => {
   try {
-    const profile = await prisma.userProfile.findFirst();
+    const profile = await prisma.profile.findFirst();
     return profile;
   } catch (error) {
     console.error("Failed to fetch profile:", error);
@@ -42,30 +16,57 @@ export const getPublicProfile = async () => {
 };
 
 export const getUserProfile = async () => {
-  const { userId } = await auth();
-  if (!userId) return null;
-  return await prisma.userProfile.findUnique({
-    where: { userId },
-    include: {
-      experiences: true,
-      educations: true,
-      skills: true,
-      projects: true,
-    },
-  });
+  try {
+    const profile = await prisma.profile.findFirst();
+    return profile;
+  } catch (error) {
+    console.error("Failed to fetch profile:", error);
+    return null;
+  }
 };
 
-export const updateUserProfile = async (id: string, data: TProfile) => {
-  const { userId } = await auth();
-  if (!userId) return { success: false, error: "Unauthorized" };
-
+export const createUserProfile = async (data: TProfile) => {
   const parsed = profileSchema.safeParse(data);
   if (!parsed.success) {
     return { success: false, error: parsed.error.message };
   }
 
   try {
-    await prisma.userProfile.update({
+    await prisma.profile.create({
+      data: {
+        fullName: parsed.data.fullName,
+        email: parsed.data.email,
+        phone: parsed.data.phone || null,
+        summary: parsed.data.summary || null,
+        title: parsed.data.title || null,
+        yearsOfExp: parsed.data.yearsOfExp || null,
+        introText: parsed.data.introText || null,
+        profileImageUrl: parsed.data.profileImageUrl || null,
+        cvUrl: parsed.data.cvUrl || null,
+        linkedinUrl: parsed.data.linkedinUrl || null,
+        githubUrl: parsed.data.githubUrl || null,
+        aboutText: parsed.data.aboutText || null,
+        location: parsed.data.location || null,
+      },
+    });
+    revalidatePath("/");
+    revalidatePath("/dashboard/profile");
+    return { success: true };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to create profile";
+    return { success: false, error: message };
+  }
+};
+
+export const updateUserProfile = async (id: string, data: TProfile) => {
+  const parsed = profileSchema.safeParse(data);
+  if (!parsed.success) {
+    return { success: false, error: parsed.error.message };
+  }
+
+  try {
+    await prisma.profile.update({
       where: { id },
       data: {
         fullName: parsed.data.fullName,
@@ -91,4 +92,4 @@ export const updateUserProfile = async (id: string, data: TProfile) => {
       error instanceof Error ? error.message : "Failed to update profile";
     return { success: false, error: message };
   }
-}
+};

--- a/actions/skill.action.ts
+++ b/actions/skill.action.ts
@@ -18,7 +18,9 @@ export const getSkills = async () => {
 
 export const createSkill = async (formData: TSkill) => {
   try {
-    await prisma.skill.create({ data: formData });
+    await prisma.skill.create({ 
+      data: formData
+    });
     revalidatePath("/");
     revalidatePath("/dashboard/skills");
     return { success: true };
@@ -33,7 +35,9 @@ export const createSkillsBulk = async (skills: string[]) => {
   try {
     // Filter out duplicates and get existing skills
     const existingSkills = await prisma.skill.findMany({
-      where: { title: { in: skills } },
+      where: { 
+        title: { in: skills }
+      },
       select: { title: true },
     });
     const existingTitles = new Set(existingSkills.map((s) => s.title));

--- a/app/api/ai/evaluate-job/route.ts
+++ b/app/api/ai/evaluate-job/route.ts
@@ -1,0 +1,37 @@
+import { generateText } from "ai";
+import { getAIModel, type AIProviderKey } from "@/lib/ai-providers";
+import { buildSystemPrompt, buildUserPrompt } from "@/lib/ai-prompts";
+import { NextRequest } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const jobDescription: string = body.jobDescription ?? body.prompt;
+    const provider: string = body.provider;
+    const profileData = body.profileData;
+
+    if (!jobDescription || !provider || !profileData) {
+      return new Response("Missing required fields", { status: 400 });
+    }
+
+    const model = getAIModel(provider as AIProviderKey);
+
+    // Use generateText (not streamText) so errors surface before headers are sent
+    const { text } = await generateText({
+      model,
+      system: buildSystemPrompt(),
+      prompt: buildUserPrompt(jobDescription, profileData),
+    });
+
+    return new Response(text, {
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to evaluate job";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/app/api/experiences/route.ts
+++ b/app/api/experiences/route.ts
@@ -3,10 +3,18 @@ import prisma from "@/prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET() {
-  const experiences = await prisma.experience.findMany({
-    orderBy: { startDate: "desc" },
-  });
-  return NextResponse.json(experiences);
+  try {
+    const experiences = await prisma.experience.findMany({
+      orderBy: { startDate: "desc" },
+    });
+    return NextResponse.json(experiences);
+  } catch (error) {
+    console.error("Error fetching experiences:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch experiences" },
+      { status: 500 },
+    );
+  }
 }
 
 export async function POST(request: NextRequest) {

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,20 +1,30 @@
 import { NextRequest, NextResponse } from "next/server";
-
 import { projectSchema } from "@/lib/validation";
 import prisma from "@/prisma/client";
 
 export async function GET() {
-  const experiences = await prisma.project.findMany();
-  return NextResponse.json(experiences);
+  try {
+    const projects = await prisma.project.findMany();
+    return NextResponse.json(projects);
+  } catch (error) {
+    console.error("Error fetching projects:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch projects" },
+      { status: 500 },
+    );
+  }
 }
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const data = projectSchema.parse(body);
-    const newProject = await prisma.project.create({ data });
+    const newProject = await prisma.project.create({ 
+      data,
+    });
     return NextResponse.json(newProject, { status: 201 });
   } catch (error) {
+    console.error("Error creating project:", error);
     return NextResponse.json(
       { error: "Validation failed", details: error },
       { status: 400 }

--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -1,38 +1,25 @@
 import { NextRequest, NextResponse } from "next/server";
-
 import { skillsArraySchema } from "@/lib/validation";
 import prisma from "@/prisma/client";
 
 export async function GET() {
-  const skills = await prisma.skill.findMany({ orderBy: { order: "asc" } });
-  console.log('skills >>>>>>. ', skills)
-  return NextResponse.json(skills);
+  try {
+    const skills = await prisma.skill.findMany({ 
+      orderBy: { order: "asc" } 
+    });
+    return NextResponse.json(skills);
+  } catch (error) {
+    console.error("Error fetching skills:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch skills" },
+      { status: 500 },
+    );
+  }
 }
-
-// export async function POST(request: NextRequest) {
-//   try {
-//     const body = await request.json();
-//     const data = skillSchema.parse(body);
-
-//     // Auto-increment order
-//     const maxOrder = await prisma.skill.aggregate({ _max: { order: true } });
-//     data.order = (maxOrder._max.order || 0) + 1;
-
-//     const newSkill = await prisma.skill.create({ data });
-//     return NextResponse.json(newSkill, { status: 201 });
-//   } catch (error) {
-//     return NextResponse.json(
-//       { error: "Validation failed", details: error },
-//       { status: 400 }
-//     );
-//   }
-// }
 
 export async function POST(request: NextRequest) {
   try {
-
     const body = await request.json();
-    console.log('body >>>>>>>>>>>>>> ', body)
 
     // Validate the input array
     const skills = skillsArraySchema.parse(body);
@@ -54,6 +41,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(createdSkills, { status: 201 });
   } catch (error) {
+    console.error("Error creating skills:", error);
     return NextResponse.json(
       { error: "Validation failed", details: error },
       { status: 400 }

--- a/app/dashboard/job-evaluator/evaluation-results.tsx
+++ b/app/dashboard/job-evaluator/evaluation-results.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { useState } from "react";
+import {
+  CheckCircle,
+  XCircle,
+  Lightbulb,
+  FileText,
+  Plus,
+  Loader2,
+  Briefcase,
+  GraduationCap,
+  Wrench,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Checkbox } from "@/components/ui/checkbox";
+
+import { type TAIEvaluationResponse } from "@/lib/validation";
+import { createSkillsBulk } from "@/actions/skill.action";
+
+interface ProfileData {
+  fullName: string;
+  email: string;
+  linkedinUrl?: string | null;
+  githubUrl?: string | null;
+  experiences: Array<{
+    id: string;
+    title: string;
+    companyName?: string | null;
+  }>;
+  educations: Array<{
+    id: string;
+    institution: string;
+    degree: string;
+  }>;
+  skills: Array<{
+    id: string;
+    title: string;
+  }>;
+}
+
+interface EvaluationResultsProps {
+  result: TAIEvaluationResponse;
+  profile: ProfileData;
+  onCreateResume: () => void;
+  isCreatingResume: boolean;
+}
+
+function getMatchColor(percentage: number) {
+  if (percentage >= 70) return "text-green-600 dark:text-green-400";
+  if (percentage >= 40) return "text-yellow-600 dark:text-yellow-400";
+  return "text-red-600 dark:text-red-400";
+}
+
+function getMatchBg(percentage: number) {
+  if (percentage >= 70) return "bg-green-100 dark:bg-green-900/30";
+  if (percentage >= 40) return "bg-yellow-100 dark:bg-yellow-900/30";
+  return "bg-red-100 dark:bg-red-900/30";
+}
+
+export default function EvaluationResults({
+  result,
+  profile,
+  onCreateResume,
+  isCreatingResume,
+}: EvaluationResultsProps) {
+  const [selectedSkills, setSelectedSkills] = useState<Set<string>>(
+    new Set(result.suggestedNewSkills)
+  );
+  const [isSavingSkills, setIsSavingSkills] = useState(false);
+  const [skillsSaved, setSkillsSaved] = useState(false);
+
+  const existingSkillTitles = new Set(profile.skills.map((s) => s.title));
+
+  // Resolve IDs to names
+  const selectedExperiences = result.suggestedResume.selectedExperienceIds
+    .map((id) => profile.experiences.find((e) => e.id === id))
+    .filter(Boolean);
+
+  const selectedEducations = result.suggestedResume.selectedEducationIds
+    .map((id) => profile.educations.find((e) => e.id === id))
+    .filter(Boolean);
+
+  const selectedSkillItems = result.suggestedResume.selectedSkillIds
+    .map((id) => profile.skills.find((s) => s.id === id))
+    .filter(Boolean);
+
+  // Filter out skills already in profile
+  const newSkills = result.suggestedNewSkills.filter(
+    (s) => !existingSkillTitles.has(s)
+  );
+
+  const toggleSkill = (skill: string) => {
+    setSelectedSkills((prev) => {
+      const next = new Set(prev);
+      if (next.has(skill)) {
+        next.delete(skill);
+      } else {
+        next.add(skill);
+      }
+      return next;
+    });
+  };
+
+  const handleSaveSkills = async () => {
+    const skills = Array.from(selectedSkills);
+    if (skills.length === 0) {
+      toast.error("No skills selected");
+      return;
+    }
+
+    setIsSavingSkills(true);
+    try {
+      const res = await createSkillsBulk(skills);
+      if (res.success) {
+        toast.success(`Added ${res.created} new skill${res.created !== 1 ? "s" : ""}`);
+        setSkillsSaved(true);
+      } else {
+        toast.error(res.error || "Failed to add skills");
+      }
+    } catch {
+      toast.error("Failed to add skills");
+    } finally {
+      setIsSavingSkills(false);
+    }
+  };
+
+  return (
+    <Tabs defaultValue="evaluation" className="w-full">
+      <TabsList className="grid w-full grid-cols-3">
+        <TabsTrigger value="evaluation">Evaluation</TabsTrigger>
+        <TabsTrigger value="resume">Suggested Resume</TabsTrigger>
+        <TabsTrigger value="skills">
+          Skill Gaps
+          {newSkills.length > 0 && (
+            <Badge variant="secondary" className="ml-2">
+              {newSkills.length}
+            </Badge>
+          )}
+        </TabsTrigger>
+      </TabsList>
+
+      {/* Evaluation Tab */}
+      <TabsContent value="evaluation" className="space-y-4">
+        {/* Match Percentage */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex flex-col items-center gap-4">
+              <div
+                className={`flex items-center justify-center w-28 h-28 rounded-full ${getMatchBg(result.evaluation.matchPercentage)}`}
+              >
+                <span
+                  className={`text-4xl font-bold ${getMatchColor(result.evaluation.matchPercentage)}`}
+                >
+                  {result.evaluation.matchPercentage}%
+                </span>
+              </div>
+              <p className="text-center text-muted-foreground max-w-lg">
+                {result.evaluation.overallAssessment}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Strengths */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg flex items-center gap-2">
+              <CheckCircle className="h-5 w-5 text-green-600" />
+              Strengths
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {result.evaluation.strengths.map((strength, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm">
+                  <CheckCircle className="h-4 w-4 text-green-600 mt-0.5 flex-shrink-0" />
+                  {strength}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        {/* Gaps */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg flex items-center gap-2">
+              <XCircle className="h-5 w-5 text-red-600" />
+              Gaps
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {result.evaluation.gaps.map((gap, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm">
+                  <XCircle className="h-4 w-4 text-red-600 mt-0.5 flex-shrink-0" />
+                  {gap}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        {/* Recommendations */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg flex items-center gap-2">
+              <Lightbulb className="h-5 w-5 text-yellow-600" />
+              Recommendations
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {result.evaluation.recommendations.map((rec, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm">
+                  <Lightbulb className="h-4 w-4 text-yellow-600 mt-0.5 flex-shrink-0" />
+                  {rec}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      {/* Suggested Resume Tab */}
+      <TabsContent value="resume" className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <FileText className="h-5 w-5" />
+              {result.suggestedResume.resumeTitle}
+            </CardTitle>
+            <CardDescription>
+              AI-tailored resume based on the job requirements
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {/* Summary */}
+            <div>
+              <h4 className="font-semibold text-sm mb-2">Professional Summary</h4>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {result.suggestedResume.summary}
+              </p>
+            </div>
+
+            {/* Selected Experiences */}
+            <div>
+              <h4 className="font-semibold text-sm mb-2 flex items-center gap-2">
+                <Briefcase className="h-4 w-4" />
+                Selected Experiences ({selectedExperiences.length})
+              </h4>
+              <ul className="space-y-1">
+                {selectedExperiences.map((exp) => (
+                  <li
+                    key={exp!.id}
+                    className="text-sm flex items-center gap-2 py-1 px-2 rounded bg-muted/50"
+                  >
+                    <CheckCircle className="h-3 w-3 text-primary flex-shrink-0" />
+                    <span className="font-medium">{exp!.title}</span>
+                    {exp!.companyName && (
+                      <span className="text-muted-foreground">
+                        at {exp!.companyName}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* Selected Education */}
+            <div>
+              <h4 className="font-semibold text-sm mb-2 flex items-center gap-2">
+                <GraduationCap className="h-4 w-4" />
+                Selected Education ({selectedEducations.length})
+              </h4>
+              <ul className="space-y-1">
+                {selectedEducations.map((edu) => (
+                  <li
+                    key={edu!.id}
+                    className="text-sm flex items-center gap-2 py-1 px-2 rounded bg-muted/50"
+                  >
+                    <CheckCircle className="h-3 w-3 text-primary flex-shrink-0" />
+                    <span className="font-medium">{edu!.degree}</span>
+                    <span className="text-muted-foreground">
+                      at {edu!.institution}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* Selected Skills */}
+            <div>
+              <h4 className="font-semibold text-sm mb-2 flex items-center gap-2">
+                <Wrench className="h-4 w-4" />
+                Selected Skills ({selectedSkillItems.length})
+              </h4>
+              <div className="flex flex-wrap gap-2">
+                {selectedSkillItems.map((skill) => (
+                  <Badge key={skill!.id} variant="secondary">
+                    {skill!.title}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+
+            <Button
+              onClick={onCreateResume}
+              disabled={isCreatingResume}
+              className="w-full"
+            >
+              {isCreatingResume ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Creating Resume...
+                </>
+              ) : (
+                <>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Create This Resume
+                </>
+              )}
+            </Button>
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      {/* Skill Gaps Tab */}
+      <TabsContent value="skills" className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Wrench className="h-5 w-5" />
+              Suggested New Skills
+            </CardTitle>
+            <CardDescription>
+              These skills were mentioned in the job description but are not in
+              your profile. Select which ones to add.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {newSkills.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                No new skills suggested - your profile already covers the
+                required skills!
+              </p>
+            ) : (
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  {newSkills.map((skill) => (
+                    <label
+                      key={skill}
+                      className="flex items-center gap-3 p-3 rounded-lg border cursor-pointer hover:bg-muted/50 transition-colors"
+                    >
+                      <Checkbox
+                        checked={selectedSkills.has(skill)}
+                        onCheckedChange={() => toggleSkill(skill)}
+                        disabled={skillsSaved}
+                      />
+                      <span className="text-sm font-medium">{skill}</span>
+                    </label>
+                  ))}
+                </div>
+
+                <Button
+                  onClick={handleSaveSkills}
+                  disabled={
+                    isSavingSkills || skillsSaved || selectedSkills.size === 0
+                  }
+                  className="w-full"
+                  variant={skillsSaved ? "outline" : "default"}
+                >
+                  {isSavingSkills ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Adding Skills...
+                    </>
+                  ) : skillsSaved ? (
+                    <>
+                      <CheckCircle className="mr-2 h-4 w-4" />
+                      Skills Added
+                    </>
+                  ) : (
+                    <>
+                      <Plus className="mr-2 h-4 w-4" />
+                      Add Selected Skills ({selectedSkills.size})
+                    </>
+                  )}
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/app/dashboard/job-evaluator/job-evaluator-client.tsx
+++ b/app/dashboard/job-evaluator/job-evaluator-client.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2, Send, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+import { AI_PROVIDERS } from "@/lib/ai-providers";
+import {
+  jobEvaluationFormSchema,
+  type TJobEvaluationForm,
+  type TAIEvaluationResponse,
+} from "@/lib/validation";
+import { createResume } from "@/actions/resume.action";
+import EvaluationResults from "./evaluation-results";
+
+interface ProfileData {
+  id: string;
+  fullName: string;
+  email: string;
+  phone?: string | null;
+  summary?: string | null;
+  title?: string | null;
+  yearsOfExp?: number | null;
+  location?: string | null;
+  linkedinUrl?: string | null;
+  githubUrl?: string | null;
+  experiences: Array<{
+    id: string;
+    title: string;
+    companyName?: string | null;
+    location?: string | null;
+    locationType?: string | null;
+    employmentType?: string | null;
+    description: string;
+    startDate: Date;
+    endDate?: Date | null;
+    current: boolean;
+  }>;
+  educations: Array<{
+    id: string;
+    institution: string;
+    degree: string;
+    description?: string | null;
+    startDate: Date;
+    endDate?: Date | null;
+    current: boolean;
+  }>;
+  skills: Array<{
+    id: string;
+    title: string;
+  }>;
+  projects: Array<{
+    id: string;
+    title: string;
+    description: string;
+    tags: string[];
+  }>;
+}
+
+interface JobEvaluatorClientProps {
+  profile: ProfileData;
+}
+
+function extractJSON(text: string): string {
+  // Strip markdown code fences that Gemini/Claude sometimes add
+  const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenceMatch) return fenceMatch[1].trim();
+  // Fall back to first { ... } block
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  return jsonMatch ? jsonMatch[0] : text;
+}
+
+export default function JobEvaluatorClient({
+  profile,
+}: JobEvaluatorClientProps) {
+  const [result, setResult] = useState<TAIEvaluationResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isCreatingResume, setIsCreatingResume] = useState(false);
+
+  const form = useForm<TJobEvaluationForm>({
+    resolver: zodResolver(jobEvaluationFormSchema),
+    defaultValues: {
+      jobDescription: "",
+      provider: "openai",
+    },
+  });
+
+  const onSubmit = async (data: TJobEvaluationForm) => {
+    setResult(null);
+    setIsLoading(true);
+
+    try {
+      const res = await fetch("/api/ai/evaluate-job", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider: data.provider,
+          jobDescription: data.jobDescription,
+          profileData: {
+            profile: {
+              fullName: profile.fullName,
+              email: profile.email,
+              title: profile.title,
+              location: profile.location,
+              yearsOfExp: profile.yearsOfExp,
+              summary: profile.summary,
+            },
+            experiences: profile.experiences,
+            educations: profile.educations,
+            skills: profile.skills,
+            projects: profile.projects,
+          },
+        }),
+      });
+
+      const text = await res.text();
+
+      if (!res.ok) {
+        // Try to parse error JSON from the response body
+        try {
+          const errData = JSON.parse(text);
+          throw new Error(errData.error || `Server error ${res.status}`);
+        } catch {
+          throw new Error(text || `Server error ${res.status}`);
+        }
+      }
+
+      const jsonStr = extractJSON(text);
+      const parsed = JSON.parse(jsonStr) as TAIEvaluationResponse;
+
+      if (!parsed.evaluation || !parsed.suggestedResume) {
+        throw new Error("Incomplete response from AI. Please try again.");
+      }
+
+      setResult(parsed);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to get AI evaluation";
+      toast.error(msg);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCreateResume = async () => {
+    if (!result) return;
+
+    setIsCreatingResume(true);
+    try {
+      const resumeResult = await createResume({
+        title: result.suggestedResume.resumeTitle,
+        experienceIds: result.suggestedResume.selectedExperienceIds,
+        educationIds: result.suggestedResume.selectedEducationIds,
+        skillIds: result.suggestedResume.selectedSkillIds,
+        content: {
+          personal: {
+            fullName: profile.fullName,
+            email: profile.email,
+            phone: profile.phone || "",
+            location: profile.location || "",
+            linkedin: profile.linkedinUrl || "",
+            website: profile.githubUrl || "",
+          },
+          summary: result.suggestedResume.summary,
+          // Store the full AI evaluation — resume editor uses this to avoid
+          // re-calling the AI and to show improvement suggestions
+          aiEvaluation: result,
+        },
+      });
+
+      if (resumeResult.success && resumeResult.data) {
+        toast.success("Resume created! Opening in new tab…");
+        window.open(`/dashboard/resumes/${resumeResult.data.id}`, "_blank");
+      } else {
+        toast.error(resumeResult.error || "Failed to create resume");
+      }
+    } catch {
+      toast.error("Failed to create resume");
+    } finally {
+      setIsCreatingResume(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Input Form */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5" />
+            Job Description
+          </CardTitle>
+          <CardDescription>
+            Paste the job requirements below and select an AI provider to
+            evaluate your fit.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="jobDescription"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Job Requirements</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Paste the full job description or requirements here..."
+                        className="min-h-[200px] resize-y"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex flex-col sm:flex-row gap-4 items-end">
+                <FormField
+                  control={form.control}
+                  name="provider"
+                  render={({ field }) => (
+                    <FormItem className="flex-1">
+                      <FormLabel>AI Provider</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select AI provider" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {AI_PROVIDERS.map((p) => (
+                            <SelectItem key={p.value} value={p.value}>
+                              {p.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <Button type="submit" disabled={isLoading} className="w-full sm:w-auto">
+                  {isLoading ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Analyzing...
+                    </>
+                  ) : (
+                    <>
+                      <Send className="mr-2 h-4 w-4" />
+                      Evaluate My Fit
+                    </>
+                  )}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      {/* Loading State */}
+      {isLoading && !result && (
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-primary mb-4" />
+            <p className="text-muted-foreground">
+              AI is analyzing your profile against the job requirements...
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Results */}
+      {result && (
+        <EvaluationResults
+          result={result}
+          profile={profile}
+          onCreateResume={handleCreateResume}
+          isCreatingResume={isCreatingResume}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/dashboard/job-evaluator/page.tsx
+++ b/app/dashboard/job-evaluator/page.tsx
@@ -1,0 +1,44 @@
+import { getUserProfile } from "@/actions/profile.action";
+import { getExperiences } from "@/actions/experience.action";
+import { getEducations } from "@/actions/education.action";
+import { getSkills } from "@/actions/skill.action";
+import { getProjects } from "@/actions/project.action";
+import { redirect } from "next/navigation";
+import JobEvaluatorClient from "./job-evaluator-client";
+
+export default async function JobEvaluatorPage() {
+  const [profile, experiences, educations, skills, projects] = await Promise.all([
+    getUserProfile(),
+    getExperiences(),
+    getEducations(),
+    getSkills(),
+    getProjects(),
+  ]);
+
+  if (!profile) {
+    redirect("/dashboard/profile");
+  }
+
+  // Combine profile with related data
+  const profileData = {
+    ...profile,
+    experiences,
+    educations,
+    skills,
+    projects,
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">AI Job Evaluator</h1>
+        <p className="text-muted-foreground">
+          Paste a job description to evaluate your fit and generate a tailored
+          resume.
+        </p>
+      </div>
+
+      <JobEvaluatorClient profile={profileData} />
+    </div>
+  );
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -40,9 +40,9 @@ export default async function RootLayout({
       }}
     >
       <SidebarProvider>
-        <AppSidebar />
+        <div className="print:hidden contents"><AppSidebar /></div>
         <SidebarInset>
-          <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12">
+          <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 print:hidden">
             <div className="w-full flex items-center justify-between gap-2 px-4 ">
               <SidebarTrigger className="-ml-1 flex-none" />
 
@@ -65,7 +65,7 @@ export default async function RootLayout({
             </div>
           </header>
           <ThemeProvider>
-            <div className="m-4">{children}</div>
+            <div className="m-4 print:m-0">{children}</div>
           </ThemeProvider>
         </SidebarInset>
       </SidebarProvider>

--- a/app/dashboard/profile/page.tsx
+++ b/app/dashboard/profile/page.tsx
@@ -1,8 +1,8 @@
-import { ensureUserProfile } from "@/actions/profile.action";
+import { getUserProfile } from "@/actions/profile.action";
 import ProfileForm from "./profile-form";
 
 export default async function ProfilePage() {
-  const profile = await ensureUserProfile();
+  const profile = await getUserProfile();
 
   return (
     <div className="space-y-6">

--- a/app/dashboard/profile/profile-form.tsx
+++ b/app/dashboard/profile/profile-form.tsx
@@ -21,26 +21,28 @@ import { ImageUpload } from "@/components/ui/image-upload";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { profileSchema, TProfile } from "@/lib/validation";
-import { updateUserProfile } from "@/actions/profile.action";
+import { createUserProfile, updateUserProfile } from "@/actions/profile.action";
 import { toast } from "sonner";
 
+interface ProfileData {
+  id: string;
+  fullName: string;
+  email: string;
+  phone?: string | null;
+  summary?: string | null;
+  title?: string | null;
+  yearsOfExp?: number | null;
+  introText?: string | null;
+  profileImageUrl?: string | null;
+  cvUrl?: string | null;
+  linkedinUrl?: string | null;
+  githubUrl?: string | null;
+  aboutText?: string | null;
+  location?: string | null;
+}
+
 interface ProfileFormProps {
-  profile: {
-    id: string;
-    fullName: string;
-    email: string;
-    phone?: string | null;
-    summary?: string | null;
-    title?: string | null;
-    yearsOfExp?: number | null;
-    introText?: string | null;
-    profileImageUrl?: string | null;
-    cvUrl?: string | null;
-    linkedinUrl?: string | null;
-    githubUrl?: string | null;
-    aboutText?: string | null;
-    location?: string | null;
-  };
+  profile: ProfileData | null;
 }
 
 export default function ProfileForm({ profile }: ProfileFormProps) {
@@ -49,29 +51,31 @@ export default function ProfileForm({ profile }: ProfileFormProps) {
   const form = useForm<TProfile>({
     resolver: zodResolver(profileSchema),
     defaultValues: {
-      fullName: profile.fullName || "",
-      email: profile.email || "",
-      phone: profile.phone || "",
-      summary: profile.summary || "",
-      title: profile.title || "",
-      yearsOfExp: profile.yearsOfExp || undefined,
-      introText: profile.introText || "",
-      profileImageUrl: profile.profileImageUrl || "",
-      cvUrl: profile.cvUrl || "",
-      linkedinUrl: profile.linkedinUrl || "",
-      githubUrl: profile.githubUrl || "",
-      aboutText: profile.aboutText || "",
-      location: profile.location || "",
+      fullName: profile?.fullName || "",
+      email: profile?.email || "",
+      phone: profile?.phone || "",
+      summary: profile?.summary || "",
+      title: profile?.title || "",
+      yearsOfExp: profile?.yearsOfExp || undefined,
+      introText: profile?.introText || "",
+      profileImageUrl: profile?.profileImageUrl || "",
+      cvUrl: profile?.cvUrl || "",
+      linkedinUrl: profile?.linkedinUrl || "",
+      githubUrl: profile?.githubUrl || "",
+      aboutText: profile?.aboutText || "",
+      location: profile?.location || "",
     },
   });
 
   async function onSubmit(values: TProfile) {
     setIsSubmitting(true);
-    const result = await updateUserProfile(profile.id, values);
+    const result = profile
+      ? await updateUserProfile(profile.id, values)
+      : await createUserProfile(values);
     if (result.success) {
-      toast.success("Profile updated successfully");
+      toast.success(profile ? "Profile updated successfully" : "Profile created successfully");
     } else {
-      toast.error(result.error || "Failed to update profile");
+      toast.error(result.error || "Failed to save profile");
     }
     setIsSubmitting(false);
   }
@@ -398,8 +402,10 @@ export default function ProfileForm({ profile }: ProfileFormProps) {
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 Saving...
               </>
-            ) : (
+            ) : profile ? (
               "Save Changes"
+            ) : (
+              "Create Profile"
             )}
           </Button>
         </div>

--- a/app/dashboard/resumes/[id]/layout.tsx
+++ b/app/dashboard/resumes/[id]/layout.tsx
@@ -4,5 +4,5 @@ export default function ResumeEditorLayout({
   children: React.ReactNode;
 }) {
   // This layout removes the default dashboard padding for the resume editor
-  return <div className="-m-4">{children}</div>;
+  return <div className="-m-4 print:m-0">{children}</div>;
 }

--- a/app/dashboard/resumes/[id]/page.tsx
+++ b/app/dashboard/resumes/[id]/page.tsx
@@ -1,5 +1,8 @@
 import { getResumeById } from "@/actions/resume.action";
 import { getUserProfile } from "@/actions/profile.action";
+import { getExperiences } from "@/actions/experience.action";
+import { getEducations } from "@/actions/education.action";
+import { getSkills } from "@/actions/skill.action";
 import { notFound } from "next/navigation";
 import ResumeEditor from "./resume-editor";
 
@@ -9,19 +12,25 @@ interface PageProps {
 
 export default async function ResumeEditPage({ params }: PageProps) {
   const { id } = await params;
-  const [resume, profile] = await Promise.all([
+  const [resume, profile, experiences, educations, skills] = await Promise.all([
     getResumeById(id),
     getUserProfile(),
+    getExperiences(),
+    getEducations(),
+    getSkills(),
   ]);
 
   if (!resume || !profile) {
     notFound();
   }
 
-  return (
-    <ResumeEditor
-      resume={resume}
-      profile={profile}
-    />
-  );
+  // Combine profile with related data for the editor
+  const profileData = {
+    ...profile,
+    experiences,
+    educations,
+    skills,
+  };
+
+  return <ResumeEditor resume={resume} profile={profileData} />;
 }

--- a/app/dashboard/resumes/[id]/resume-editor.tsx
+++ b/app/dashboard/resumes/[id]/resume-editor.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { RichTextEditor } from "@/components/ui/rich-text-editor";
+import { RichTextViewer } from "@/components/ui/rich-text-viewer";
 import { updateResume } from "@/actions/resume.action";
 import { toast } from "sonner";
 import {
@@ -15,25 +16,110 @@ import {
   Save,
   ChevronLeft,
   Download,
+  Plus,
+  Trash2,
+  Edit,
+  ExternalLink,
+  Sparkles,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
 } from "lucide-react";
 import Link from "next/link";
 import ResumePreview from "./resume-preview";
+import { format } from "date-fns";
 
-type Section = "personal" | "summary" | "experience" | "education" | "skills";
+// ─── Types ────────────────────────────────────────────────────────────────────
 
-interface ResumeContent {
-  personal?: {
-    fullName?: string;
-    email?: string;
-    phone?: string;
-    location?: string;
-    linkedin?: string;
-    website?: string;
+type Section = "personal" | "summary" | "experience" | "education" | "skills" | "ai";
+
+/** Personal info overrides stored in resume.content */
+interface PersonalOverride {
+  fullName?: string;
+  title?: string;
+  email?: string;
+  phone?: string;
+  location?: string;
+  linkedin?: string;
+  website?: string;
+}
+
+interface AIEvaluation {
+  evaluation: {
+    matchPercentage: number;
+    overallAssessment: string;
+    strengths: string[];
+    gaps: string[];
+    recommendations: string[];
   };
+  suggestedResume: {
+    resumeTitle: string;
+    summary: string;
+    selectedExperienceIds: string[];
+    selectedEducationIds: string[];
+    selectedSkillIds: string[];
+  };
+  suggestedNewSkills: string[];
+}
+
+/** Summary override stored in resume.content */
+interface ResumeContent {
+  personal?: PersonalOverride;
   summary?: string;
-  selectedExperiences?: string[];
-  selectedEducations?: string[];
-  selectedSkills?: string[];
+  aiEvaluation?: AIEvaluation;
+}
+
+/** Custom (resume-only) experience not saved to the DB */
+interface CustomExperience {
+  id: string;
+  title: string;
+  companyName: string;
+  location: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  current: boolean;
+}
+
+/** Custom (resume-only) education not saved to the DB */
+interface CustomEducation {
+  id: string;
+  institution: string;
+  degree: string;
+  startDate: string;
+  endDate: string;
+  current: boolean;
+}
+
+/** Custom (resume-only) skill not saved to the DB */
+interface CustomSkill {
+  id: string;
+  title: string;
+}
+
+interface DBExperience {
+  id: string;
+  title: string;
+  companyName?: string | null;
+  location?: string | null;
+  description: string;
+  startDate: Date;
+  endDate?: Date | null;
+  current: boolean;
+}
+
+interface DBEducation {
+  id: string;
+  institution: string;
+  degree: string;
+  startDate: Date;
+  endDate?: Date | null;
+  current: boolean;
+}
+
+interface DBSkill {
+  id: string;
+  title: string;
 }
 
 interface ResumeEditorProps {
@@ -42,365 +128,739 @@ interface ResumeEditorProps {
     title: string;
     layout: string;
     themeColor: string;
-    content: any;
+    // ID arrays from new schema
+    experienceIds: string[];
+    educationIds: string[];
+    skillIds: string[];
+    // Optional JSON content for personal overrides (Prisma returns JsonValue)
+    content: unknown;
   };
   profile: {
-    id: string;
     fullName: string;
+    title?: string | null;
     email: string;
     phone?: string | null;
+    location?: string | null;
     summary?: string | null;
-    experiences: Array<{
-      id: string;
-      title: string;
-      companyName?: string | null;
-      location?: string | null;
-      description: string;
-      startDate: Date;
-      endDate?: Date | null;
-      current: boolean;
-    }>;
-    educations: Array<{
-      id: string;
-      institution: string;
-      degree: string;
-      startDate: Date;
-      endDate?: Date | null;
-      current: boolean;
-    }>;
-    skills: Array<{
-      id: string;
-      title: string;
-    }>;
+    linkedinUrl?: string | null;
+    websiteUrl?: string | null;
+    experiences: DBExperience[];
+    educations: DBEducation[];
+    skills: DBSkill[];
   };
 }
 
+// ─── Section nav config ───────────────────────────────────────────────────────
+
 const sections: { id: Section; label: string; icon: React.ReactNode }[] = [
-  {
-    id: "personal",
-    label: "Personal Details",
-    icon: <User className="h-4 w-4" />,
-  },
-  { id: "summary", label: "Summary", icon: <FileText className="h-4 w-4" /> },
-  {
-    id: "experience",
-    label: "Experience",
-    icon: <Briefcase className="h-4 w-4" />,
-  },
-  {
-    id: "education",
-    label: "Education",
-    icon: <GraduationCap className="h-4 w-4" />,
-  },
-  { id: "skills", label: "Skills", icon: <Wrench className="h-4 w-4" /> },
+  { id: "personal",   label: "Personal",   icon: <User className="h-4 w-4" /> },
+  { id: "summary",    label: "Summary",    icon: <FileText className="h-4 w-4" /> },
+  { id: "experience", label: "Experience", icon: <Briefcase className="h-4 w-4" /> },
+  { id: "education",  label: "Education",  icon: <GraduationCap className="h-4 w-4" /> },
+  { id: "skills",     label: "Skills",     icon: <Wrench className="h-4 w-4" /> },
+  { id: "ai",         label: "AI",         icon: <Sparkles className="h-4 w-4" /> },
 ];
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 export default function ResumeEditor({ resume, profile }: ResumeEditorProps) {
   const [activeSection, setActiveSection] = useState<Section>("personal");
   const [isPending, startTransition] = useTransition();
   const [title, setTitle] = useState(resume.title);
 
-  const initialContent: ResumeContent = resume.content || {};
-  const [content, setContent] = useState<ResumeContent>({
-    personal: {
-      fullName: initialContent.personal?.fullName || profile.fullName,
-      email: initialContent.personal?.email || profile.email,
-      phone: initialContent.personal?.phone || profile.phone || "",
-      location: initialContent.personal?.location || "",
-      linkedin: initialContent.personal?.linkedin || "",
-      website: initialContent.personal?.website || "",
-    },
-    summary: initialContent.summary || profile.summary || "",
-    selectedExperiences:
-      initialContent.selectedExperiences ||
-      profile.experiences.map((e) => e.id),
-    selectedEducations:
-      initialContent.selectedEducations || profile.educations.map((e) => e.id),
-    selectedSkills:
-      initialContent.selectedSkills || profile.skills.map((s) => s.id),
+  // ── Selected DB IDs ──────────────────────────────────────────────────────
+  const [selectedExpIds, setSelectedExpIds] = useState<string[]>(
+    resume.experienceIds ?? [],
+  );
+  const [selectedEduIds, setSelectedEduIds] = useState<string[]>(
+    resume.educationIds ?? [],
+  );
+  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>(
+    resume.skillIds ?? [],
+  );
+
+  // ── Custom resume-only items ─────────────────────────────────────────────
+  type SavedContent = ResumeContent & {
+    customExperiences?: CustomExperience[];
+    customEducations?: CustomEducation[];
+    customSkills?: CustomSkill[];
+  };
+  const savedContent: SavedContent =
+    (resume.content as SavedContent) ?? {};
+
+  const [personal, setPersonal] = useState<PersonalOverride>({
+    fullName:  savedContent.personal?.fullName  ?? profile.fullName,
+    title:     savedContent.personal?.title     ?? profile.title    ?? "",
+    email:     savedContent.personal?.email     ?? profile.email,
+    phone:     savedContent.personal?.phone     ?? profile.phone    ?? "",
+    location:  savedContent.personal?.location  ?? profile.location ?? "",
+    linkedin:  savedContent.personal?.linkedin  ?? profile.linkedinUrl ?? "",
+    website:   savedContent.personal?.website   ?? profile.websiteUrl  ?? "",
   });
 
+  const [summary, setSummary] = useState<string>(
+    savedContent.summary ?? profile.summary ?? "",
+  );
+
+  const [customExperiences, setCustomExperiences] = useState<CustomExperience[]>(
+    savedContent.customExperiences ?? [],
+  );
+  const [customEducations, setCustomEducations] = useState<CustomEducation[]>(
+    savedContent.customEducations ?? [],
+  );
+  const [customSkills, setCustomSkills] = useState<CustomSkill[]>(
+    savedContent.customSkills ?? [],
+  );
+
+  const [editingExpId, setEditingExpId] = useState<string | null>(null);
+  const [editingEduId, setEditingEduId] = useState<string | null>(null);
+
+  // ── Save ─────────────────────────────────────────────────────────────────
   const handleSave = () => {
     startTransition(async () => {
       const result = await updateResume(resume.id, {
         title,
-        content,
+        experienceIds: selectedExpIds,
+        educationIds:  selectedEduIds,
+        skillIds:      selectedSkillIds,
+        content: {
+          personal,
+          summary,
+          customExperiences,
+          customEducations,
+          customSkills,
+        },
       });
       if (result.success) {
-        toast.success("Resume saved successfully");
+        toast.success("Resume saved");
       } else {
         toast.error("Failed to save resume");
       }
     });
   };
 
-  const updatePersonal = (field: string, value: string) => {
-    setContent((prev) => ({
-      ...prev,
-      personal: {
-        ...prev.personal,
-        [field]: value,
-      },
-    }));
+  const handleDownloadPDF = () => window.print();
+
+  // ── Toggle DB items ───────────────────────────────────────────────────────
+  const toggleExp = (id: string) =>
+    setSelectedExpIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+
+  const toggleEdu = (id: string) =>
+    setSelectedEduIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+
+  const toggleSkill = (id: string) =>
+    setSelectedSkillIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    );
+
+  // ── Custom experience helpers ─────────────────────────────────────────────
+  const addCustomExp = () => {
+    const item: CustomExperience = {
+      id: `cexp-${Date.now()}`,
+      title: "", companyName: "", location: "",
+      description: "", startDate: "", endDate: "", current: false,
+    };
+    setCustomExperiences((prev) => [...prev, item]);
+    setEditingExpId(item.id);
   };
 
-  const toggleExperience = (id: string) => {
-    setContent((prev) => ({
-      ...prev,
-      selectedExperiences: prev.selectedExperiences?.includes(id)
-        ? prev.selectedExperiences.filter((e) => e !== id)
-        : [...(prev.selectedExperiences || []), id],
-    }));
+  const updateCustomExp = (id: string, field: keyof CustomExperience, value: string | boolean) =>
+    setCustomExperiences((prev) =>
+      prev.map((e) => (e.id === id ? { ...e, [field]: value } : e)),
+    );
+
+  const deleteCustomExp = (id: string) => {
+    setCustomExperiences((prev) => prev.filter((e) => e.id !== id));
+    if (editingExpId === id) setEditingExpId(null);
   };
 
-  const toggleEducation = (id: string) => {
-    setContent((prev) => ({
-      ...prev,
-      selectedEducations: prev.selectedEducations?.includes(id)
-        ? prev.selectedEducations.filter((e) => e !== id)
-        : [...(prev.selectedEducations || []), id],
-    }));
+  // ── Custom education helpers ──────────────────────────────────────────────
+  const addCustomEdu = () => {
+    const item: CustomEducation = {
+      id: `cedu-${Date.now()}`,
+      institution: "", degree: "",
+      startDate: "", endDate: "", current: false,
+    };
+    setCustomEducations((prev) => [...prev, item]);
+    setEditingEduId(item.id);
   };
 
-  const toggleSkill = (id: string) => {
-    setContent((prev) => ({
-      ...prev,
-      selectedSkills: prev.selectedSkills?.includes(id)
-        ? prev.selectedSkills.filter((s) => s !== id)
-        : [...(prev.selectedSkills || []), id],
-    }));
+  const updateCustomEdu = (id: string, field: keyof CustomEducation, value: string | boolean) =>
+    setCustomEducations((prev) =>
+      prev.map((e) => (e.id === id ? { ...e, [field]: value } : e)),
+    );
+
+  const deleteCustomEdu = (id: string) => {
+    setCustomEducations((prev) => prev.filter((e) => e.id !== id));
+    if (editingEduId === id) setEditingEduId(null);
   };
 
-  const selectedExperiences = profile.experiences.filter((e) =>
-    content.selectedExperiences?.includes(e.id),
-  );
-  const selectedEducations = profile.educations.filter((e) =>
-    content.selectedEducations?.includes(e.id),
-  );
-  const selectedSkills = profile.skills.filter((s) =>
-    content.selectedSkills?.includes(s.id),
-  );
+  // ── Custom skill helpers ──────────────────────────────────────────────────
+  const addCustomSkill = () => {
+    const item: CustomSkill = { id: `csk-${Date.now()}`, title: "" };
+    setCustomSkills((prev) => [...prev, item]);
+  };
 
+  const updateCustomSkill = (id: string, value: string) =>
+    setCustomSkills((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, title: value } : s)),
+    );
+
+  const deleteCustomSkill = (id: string) =>
+    setCustomSkills((prev) => prev.filter((s) => s.id !== id));
+
+  // ── Build preview data ────────────────────────────────────────────────────
+  const previewExperiences = [
+    ...profile.experiences.filter((e) => selectedExpIds.includes(e.id)),
+    ...customExperiences.map((e) => ({
+      ...e,
+      startDate: e.startDate ? new Date(e.startDate) : new Date(),
+      endDate:   e.endDate   ? new Date(e.endDate)   : null,
+    })),
+  ];
+
+  const previewEducations = [
+    ...profile.educations.filter((e) => selectedEduIds.includes(e.id)),
+    ...customEducations.map((e) => ({
+      ...e,
+      startDate: e.startDate ? new Date(e.startDate) : new Date(),
+      endDate:   e.endDate   ? new Date(e.endDate)   : null,
+    })),
+  ];
+
+  const previewSkills = [
+    ...profile.skills.filter((s) => selectedSkillIds.includes(s.id)),
+    ...customSkills,
+  ];
+
+  // ─── Render ────────────────────────────────────────────────────────────────
   return (
-    <div className="flex h-[calc(100vh-4rem)] overflow-hidden">
-      {/* Left Sidebar - Editor */}
-      <div className="w-[400px] border-r flex flex-col bg-background">
+    <div className="flex h-[calc(100vh-4rem)] overflow-hidden print:h-auto print:overflow-visible">
+
+      {/* ── Left Sidebar ─────────────────────────────────────────────── */}
+      <div className="w-[420px] border-r flex flex-col bg-background print:hidden">
+
         {/* Header */}
-        <div className="p-4 border-b flex items-center justify-between">
-          <div className="flex items-center gap-2">
+        <div className="p-4 border-b flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 min-w-0">
             <Link href="/dashboard/resumes">
-              <Button variant="ghost" size="icon">
+              <Button variant="ghost" size="icon" className="shrink-0">
                 <ChevronLeft className="h-4 w-4" />
               </Button>
             </Link>
             <Input
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="h-8 w-48 font-medium"
+              className="h-8 font-medium"
             />
           </div>
-          <Button onClick={handleSave} disabled={isPending} size="sm">
+          <Button onClick={handleSave} disabled={isPending} size="sm" className="shrink-0">
             <Save className="h-4 w-4 mr-2" />
-            {isPending ? "Saving..." : "Save"}
+            {isPending ? "Saving…" : "Save"}
           </Button>
         </div>
 
-        {/* Section Navigation */}
-        <div className="flex border-b overflow-x-auto">
-          {sections.map((section) => (
+        {/* Section tabs */}
+        <div className="flex border-b overflow-x-auto shrink-0">
+          {sections.map((s) => (
             <button
-              key={section.id}
-              onClick={() => setActiveSection(section.id)}
-              className={`flex items-center gap-2 px-4 py-3 text-sm whitespace-nowrap border-b-2 transition-colors ${
-                activeSection === section.id
+              key={s.id}
+              onClick={() => setActiveSection(s.id)}
+              className={`flex items-center gap-1.5 px-3 py-3 text-xs whitespace-nowrap border-b-2 transition-colors ${
+                activeSection === s.id
                   ? "border-primary text-primary"
                   : "border-transparent text-muted-foreground hover:text-foreground"
               }`}
             >
-              {section.icon}
-              <span className="hidden sm:inline">{section.label}</span>
+              {s.icon}
+              {s.label}
             </button>
           ))}
         </div>
 
-        {/* Section Content */}
-        <div className="flex-1 overflow-y-auto p-4">
+        {/* Section content */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+
+          {/* ── Personal ──────────────────────────────────────────────── */}
           {activeSection === "personal" && (
-            <div className="space-y-4">
-              <h3 className="font-semibold text-lg">Personal Details</h3>
-              <div className="space-y-3">
-                <div>
-                  <label className="text-sm font-medium">Full Name</label>
+            <div className="space-y-3">
+              <h3 className="font-semibold">Personal Details</h3>
+              {(
+                [
+                  { label: "Full Name",         field: "fullName",  placeholder: "John Doe" },
+                  { label: "Professional Title", field: "title",     placeholder: "Full Stack Engineer" },
+                  { label: "Email",              field: "email",     placeholder: "john@example.com" },
+                  { label: "Phone",              field: "phone",     placeholder: "+1 234 567 890" },
+                  { label: "Location",           field: "location",  placeholder: "Dubai, UAE" },
+                  { label: "LinkedIn",           field: "linkedin",  placeholder: "linkedin.com/in/…" },
+                  { label: "Website",            field: "website",   placeholder: "yoursite.com" },
+                ] as { label: string; field: keyof PersonalOverride; placeholder: string }[]
+              ).map(({ label, field, placeholder }) => (
+                <div key={field}>
+                  <label className="text-sm font-medium">{label}</label>
                   <Input
-                    value={content.personal?.fullName || ""}
-                    onChange={(e) => updatePersonal("fullName", e.target.value)}
-                    placeholder="John Doe"
+                    value={personal[field] ?? ""}
+                    onChange={(e) =>
+                      setPersonal((prev) => ({ ...prev, [field]: e.target.value }))
+                    }
+                    placeholder={placeholder}
                   />
                 </div>
-                <div>
-                  <label className="text-sm font-medium">Email</label>
-                  <Input
-                    value={content.personal?.email || ""}
-                    onChange={(e) => updatePersonal("email", e.target.value)}
-                    placeholder="john@example.com"
-                  />
-                </div>
-                <div>
-                  <label className="text-sm font-medium">Phone</label>
-                  <Input
-                    value={content.personal?.phone || ""}
-                    onChange={(e) => updatePersonal("phone", e.target.value)}
-                    placeholder="+1 234 567 890"
-                  />
-                </div>
-                <div>
-                  <label className="text-sm font-medium">Location</label>
-                  <Input
-                    value={content.personal?.location || ""}
-                    onChange={(e) => updatePersonal("location", e.target.value)}
-                    placeholder="New York, USA"
-                  />
-                </div>
-                <div>
-                  <label className="text-sm font-medium">LinkedIn</label>
-                  <Input
-                    value={content.personal?.linkedin || ""}
-                    onChange={(e) => updatePersonal("linkedin", e.target.value)}
-                    placeholder="linkedin.com/in/johndoe"
-                  />
-                </div>
-                <div>
-                  <label className="text-sm font-medium">Website</label>
-                  <Input
-                    value={content.personal?.website || ""}
-                    onChange={(e) => updatePersonal("website", e.target.value)}
-                    placeholder="johndoe.com"
-                  />
-                </div>
-              </div>
+              ))}
             </div>
           )}
 
+          {/* ── Summary ───────────────────────────────────────────────── */}
           {activeSection === "summary" && (
-            <div className="space-y-4">
-              <h3 className="font-semibold text-lg">Professional Summary</h3>
+            <div className="space-y-3">
+              <h3 className="font-semibold">Professional Summary</h3>
               <RichTextEditor
-                value={content.summary || ""}
-                onChange={(value) =>
-                  setContent((prev) => ({ ...prev, summary: value }))
-                }
-                placeholder="Write a brief professional summary..."
+                value={summary}
+                onChange={setSummary}
+                placeholder="Write a brief professional summary…"
               />
             </div>
           )}
 
+          {/* ── Experience ────────────────────────────────────────────── */}
           {activeSection === "experience" && (
             <div className="space-y-4">
-              <h3 className="font-semibold text-lg">Experience</h3>
-              <p className="text-sm text-muted-foreground">
-                Select which experiences to include in this resume.
-              </p>
-              {profile.experiences.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-4">
-                  No experiences added yet. Add them in your profile.
-                </p>
-              ) : (
+              <div className="flex items-center justify-between">
+                <h3 className="font-semibold">Experience</h3>
+                <div className="flex gap-2">
+                  <Button variant="outline" size="sm" onClick={addCustomExp}>
+                    <Plus className="h-4 w-4 mr-1" /> Custom
+                  </Button>
+                  <Link href="/dashboard/experience" target="_blank">
+                    <Button variant="outline" size="sm">
+                      <ExternalLink className="h-4 w-4 mr-1" /> Manage
+                    </Button>
+                  </Link>
+                </div>
+              </div>
+
+              {/* DB experiences */}
+              {profile.experiences.length > 0 && (
                 <div className="space-y-2">
-                  {profile.experiences.map((exp) => (
-                    <label
-                      key={exp.id}
-                      className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
-                        content.selectedExperiences?.includes(exp.id)
-                          ? "border-primary bg-primary/5"
-                          : "border-border hover:bg-muted/50"
-                      }`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={content.selectedExperiences?.includes(exp.id)}
-                        onChange={() => toggleExperience(exp.id)}
-                        className="mt-1"
-                      />
-                      <div className="flex-1">
-                        <p className="font-medium text-sm">{exp.title}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {exp.companyName}
-                          {exp.companyName && exp.location ? " · " : ""}
-                          {exp.location}
-                        </p>
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    From Profile ({profile.experiences.length})
+                  </p>
+                  {profile.experiences.map((exp) => {
+                    const selected = selectedExpIds.includes(exp.id);
+                    return (
+                      <div
+                        key={exp.id}
+                        className={`rounded-lg border transition-colors ${
+                          selected ? "border-primary bg-primary/5" : "border-border"
+                        }`}
+                      >
+                        <label className="flex items-start gap-3 p-3 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={selected}
+                            onChange={() => toggleExp(exp.id)}
+                            className="mt-1 shrink-0"
+                          />
+                          <div className="flex-1 min-w-0">
+                            <p className="font-medium text-sm truncate">{exp.title}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {exp.companyName}
+                              {exp.location ? ` · ${exp.location}` : ""}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {format(new Date(exp.startDate), "MMM yyyy")} –{" "}
+                              {exp.current
+                                ? "Present"
+                                : exp.endDate
+                                ? format(new Date(exp.endDate), "MMM yyyy")
+                                : "N/A"}
+                            </p>
+                          </div>
+                        </label>
+                        {selected && (
+                          <div className="px-3 pb-3 pl-10">
+                            <div className="text-xs border rounded p-2 bg-muted/30">
+                              <RichTextViewer content={exp.description} />
+                            </div>
+                          </div>
+                        )}
                       </div>
-                    </label>
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Custom experiences */}
+              {customExperiences.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Resume-only
+                  </p>
+                  {customExperiences.map((exp) => (
+                    <div
+                      key={exp.id}
+                      className="p-3 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-800"
+                    >
+                      {editingExpId === exp.id ? (
+                        <div className="space-y-2">
+                          <Input value={exp.title} onChange={(e) => updateCustomExp(exp.id, "title", e.target.value)} placeholder="Job Title" className="h-8 text-sm" />
+                          <Input value={exp.companyName} onChange={(e) => updateCustomExp(exp.id, "companyName", e.target.value)} placeholder="Company" className="h-8 text-sm" />
+                          <Input value={exp.location} onChange={(e) => updateCustomExp(exp.id, "location", e.target.value)} placeholder="Location" className="h-8 text-sm" />
+                          <div className="grid grid-cols-2 gap-2">
+                            <Input type="date" value={exp.startDate} onChange={(e) => updateCustomExp(exp.id, "startDate", e.target.value)} className="h-8 text-sm" />
+                            <Input type="date" value={exp.endDate} onChange={(e) => updateCustomExp(exp.id, "endDate", e.target.value)} disabled={exp.current} className="h-8 text-sm" />
+                          </div>
+                          <label className="flex items-center gap-2 text-sm">
+                            <input type="checkbox" checked={exp.current} onChange={(e) => updateCustomExp(exp.id, "current", e.target.checked)} />
+                            Currently working here
+                          </label>
+                          <RichTextEditor value={exp.description} onChange={(v) => updateCustomExp(exp.id, "description", v)} placeholder="Responsibilities…" />
+                          <div className="flex gap-2 pt-1">
+                            <Button size="sm" onClick={() => setEditingExpId(null)}>Done</Button>
+                            <Button size="sm" variant="destructive" onClick={() => deleteCustomExp(exp.id)}>
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="flex items-start justify-between gap-2">
+                          <div>
+                            <p className="font-medium text-sm">{exp.title || "Untitled"}</p>
+                            <p className="text-xs text-muted-foreground">{exp.companyName || "No company"}</p>
+                          </div>
+                          <Button size="sm" variant="ghost" onClick={() => setEditingExpId(exp.id)}>
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      )}
+                    </div>
                   ))}
+                </div>
+              )}
+
+              {profile.experiences.length === 0 && customExperiences.length === 0 && (
+                <div className="text-center py-8 border-2 border-dashed rounded-lg">
+                  <Briefcase className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
+                  <p className="text-sm text-muted-foreground">No experiences yet</p>
                 </div>
               )}
             </div>
           )}
 
+          {/* ── Education ─────────────────────────────────────────────── */}
           {activeSection === "education" && (
             <div className="space-y-4">
-              <h3 className="font-semibold text-lg">Education</h3>
-              <p className="text-sm text-muted-foreground">
-                Select which education entries to include.
-              </p>
-              {profile.educations.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-4">
-                  No education added yet. Add them in your profile.
-                </p>
-              ) : (
+              <div className="flex items-center justify-between">
+                <h3 className="font-semibold">Education</h3>
+                <div className="flex gap-2">
+                  <Button variant="outline" size="sm" onClick={addCustomEdu}>
+                    <Plus className="h-4 w-4 mr-1" /> Custom
+                  </Button>
+                  <Link href="/dashboard/education" target="_blank">
+                    <Button variant="outline" size="sm">
+                      <ExternalLink className="h-4 w-4 mr-1" /> Manage
+                    </Button>
+                  </Link>
+                </div>
+              </div>
+
+              {/* DB educations */}
+              {profile.educations.length > 0 && (
                 <div className="space-y-2">
-                  {profile.educations.map((edu) => (
-                    <label
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    From Profile ({profile.educations.length})
+                  </p>
+                  {profile.educations.map((edu) => {
+                    const selected = selectedEduIds.includes(edu.id);
+                    return (
+                      <label
+                        key={edu.id}
+                        className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                          selected ? "border-primary bg-primary/5" : "border-border"
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selected}
+                          onChange={() => toggleEdu(edu.id)}
+                          className="mt-1 shrink-0"
+                        />
+                        <div className="flex-1">
+                          <p className="font-medium text-sm">{edu.degree}</p>
+                          <p className="text-xs text-muted-foreground">{edu.institution}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {format(new Date(edu.startDate), "MMM yyyy")} –{" "}
+                            {edu.current
+                              ? "Present"
+                              : edu.endDate
+                              ? format(new Date(edu.endDate), "MMM yyyy")
+                              : "N/A"}
+                          </p>
+                        </div>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Custom educations */}
+              {customEducations.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Resume-only
+                  </p>
+                  {customEducations.map((edu) => (
+                    <div
                       key={edu.id}
-                      className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
-                        content.selectedEducations?.includes(edu.id)
-                          ? "border-primary bg-primary/5"
-                          : "border-border hover:bg-muted/50"
-                      }`}
+                      className="p-3 rounded-lg border border-amber-200 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-800"
                     >
-                      <input
-                        type="checkbox"
-                        checked={content.selectedEducations?.includes(edu.id)}
-                        onChange={() => toggleEducation(edu.id)}
-                        className="mt-1"
-                      />
-                      <div className="flex-1">
-                        <p className="font-medium text-sm">{edu.degree}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {edu.institution}
-                        </p>
-                      </div>
-                    </label>
+                      {editingEduId === edu.id ? (
+                        <div className="space-y-2">
+                          <Input value={edu.degree} onChange={(e) => updateCustomEdu(edu.id, "degree", e.target.value)} placeholder="Degree" className="h-8 text-sm" />
+                          <Input value={edu.institution} onChange={(e) => updateCustomEdu(edu.id, "institution", e.target.value)} placeholder="Institution" className="h-8 text-sm" />
+                          <div className="grid grid-cols-2 gap-2">
+                            <Input type="date" value={edu.startDate} onChange={(e) => updateCustomEdu(edu.id, "startDate", e.target.value)} className="h-8 text-sm" />
+                            <Input type="date" value={edu.endDate} onChange={(e) => updateCustomEdu(edu.id, "endDate", e.target.value)} disabled={edu.current} className="h-8 text-sm" />
+                          </div>
+                          <label className="flex items-center gap-2 text-sm">
+                            <input type="checkbox" checked={edu.current} onChange={(e) => updateCustomEdu(edu.id, "current", e.target.checked)} />
+                            Currently studying
+                          </label>
+                          <div className="flex gap-2 pt-1">
+                            <Button size="sm" onClick={() => setEditingEduId(null)}>Done</Button>
+                            <Button size="sm" variant="destructive" onClick={() => deleteCustomEdu(edu.id)}>
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="flex items-start justify-between gap-2">
+                          <div>
+                            <p className="font-medium text-sm">{edu.degree || "Untitled"}</p>
+                            <p className="text-xs text-muted-foreground">{edu.institution || "No institution"}</p>
+                          </div>
+                          <Button size="sm" variant="ghost" onClick={() => setEditingEduId(edu.id)}>
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      )}
+                    </div>
                   ))}
+                </div>
+              )}
+
+              {profile.educations.length === 0 && customEducations.length === 0 && (
+                <div className="text-center py-8 border-2 border-dashed rounded-lg">
+                  <GraduationCap className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
+                  <p className="text-sm text-muted-foreground">No education yet</p>
                 </div>
               )}
             </div>
           )}
 
+          {/* ── Skills ────────────────────────────────────────────────── */}
           {activeSection === "skills" && (
             <div className="space-y-4">
-              <h3 className="font-semibold text-lg">Skills</h3>
-              <p className="text-sm text-muted-foreground">
-                Select skills to include in this resume.
-              </p>
-              {profile.skills.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-4">
-                  No skills added yet. Add them in your profile.
-                </p>
+              <div className="flex items-center justify-between">
+                <h3 className="font-semibold">Skills</h3>
+                <div className="flex gap-2">
+                  <Button variant="outline" size="sm" onClick={addCustomSkill}>
+                    <Plus className="h-4 w-4 mr-1" /> Custom
+                  </Button>
+                  <Link href="/dashboard/skills" target="_blank">
+                    <Button variant="outline" size="sm">
+                      <ExternalLink className="h-4 w-4 mr-1" /> Manage
+                    </Button>
+                  </Link>
+                </div>
+              </div>
+
+              {/* DB skills */}
+              {profile.skills.length > 0 && (
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      From Profile ({profile.skills.length})
+                    </p>
+                    <span className="text-xs text-muted-foreground">
+                      {selectedSkillIds.length} selected
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {profile.skills.map((skill) => {
+                      const selected = selectedSkillIds.includes(skill.id);
+                      return (
+                        <button
+                          key={skill.id}
+                          onClick={() => toggleSkill(skill.id)}
+                          className={`px-3 py-1.5 text-sm rounded-full border transition-colors ${
+                            selected
+                              ? "border-primary bg-primary text-primary-foreground"
+                              : "border-border hover:bg-muted"
+                          }`}
+                        >
+                          {skill.title}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Custom skills */}
+              {customSkills.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Resume-only
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {customSkills.map((skill) => (
+                      <div
+                        key={skill.id}
+                        className="flex items-center gap-1 px-2 py-1 rounded-full border border-amber-200 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-800"
+                      >
+                        <Input
+                          value={skill.title}
+                          onChange={(e) => updateCustomSkill(skill.id, e.target.value)}
+                          placeholder="Skill name"
+                          className="h-5 w-24 text-xs border-0 bg-transparent p-0 focus-visible:ring-0"
+                        />
+                        <button
+                          onClick={() => deleteCustomSkill(skill.id)}
+                          className="text-muted-foreground hover:text-destructive"
+                        >
+                          <Trash2 className="h-3 w-3" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {profile.skills.length === 0 && customSkills.length === 0 && (
+                <div className="text-center py-8 border-2 border-dashed rounded-lg">
+                  <Wrench className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
+                  <p className="text-sm text-muted-foreground">No skills yet</p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ── AI Insights ───────────────────────────────────────────── */}
+          {activeSection === "ai" && (
+            <div className="space-y-4">
+              {savedContent.aiEvaluation ? (
+                <>
+                  {/* Match score */}
+                  <div className="rounded-lg border p-4 space-y-2">
+                    <div className="flex items-center justify-between">
+                      <h3 className="font-semibold text-sm">Job Match</h3>
+                      <span
+                        className="text-2xl font-bold"
+                        style={{
+                          color:
+                            savedContent.aiEvaluation.evaluation.matchPercentage >= 70
+                              ? "#16a34a"
+                              : savedContent.aiEvaluation.evaluation.matchPercentage >= 40
+                              ? "#d97706"
+                              : "#dc2626",
+                        }}
+                      >
+                        {savedContent.aiEvaluation.evaluation.matchPercentage}%
+                      </span>
+                    </div>
+                    <div className="w-full bg-muted rounded-full h-2">
+                      <div
+                        className="h-2 rounded-full transition-all"
+                        style={{
+                          width: `${savedContent.aiEvaluation.evaluation.matchPercentage}%`,
+                          backgroundColor:
+                            savedContent.aiEvaluation.evaluation.matchPercentage >= 70
+                              ? "#16a34a"
+                              : savedContent.aiEvaluation.evaluation.matchPercentage >= 40
+                              ? "#d97706"
+                              : "#dc2626",
+                        }}
+                      />
+                    </div>
+                    <p className="text-xs text-muted-foreground leading-relaxed">
+                      {savedContent.aiEvaluation.evaluation.overallAssessment}
+                    </p>
+                  </div>
+
+                  {/* Strengths */}
+                  <div className="rounded-lg border p-4 space-y-2">
+                    <h3 className="font-semibold text-sm flex items-center gap-2">
+                      <CheckCircle2 className="h-4 w-4 text-green-500" /> Strengths
+                    </h3>
+                    <ul className="space-y-1">
+                      {savedContent.aiEvaluation.evaluation.strengths.map((s, i) => (
+                        <li key={i} className="text-xs text-muted-foreground flex items-start gap-2">
+                          <span className="text-green-500 mt-0.5">•</span>{s}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  {/* Gaps */}
+                  <div className="rounded-lg border p-4 space-y-2">
+                    <h3 className="font-semibold text-sm flex items-center gap-2">
+                      <XCircle className="h-4 w-4 text-red-500" /> Gaps
+                    </h3>
+                    <ul className="space-y-1">
+                      {savedContent.aiEvaluation.evaluation.gaps.map((g, i) => (
+                        <li key={i} className="text-xs text-muted-foreground flex items-start gap-2">
+                          <span className="text-red-500 mt-0.5">•</span>{g}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  {/* Recommendations */}
+                  <div className="rounded-lg border p-4 space-y-2">
+                    <h3 className="font-semibold text-sm flex items-center gap-2">
+                      <AlertCircle className="h-4 w-4 text-amber-500" /> Recommendations
+                    </h3>
+                    <ul className="space-y-1">
+                      {savedContent.aiEvaluation.evaluation.recommendations.map((r, i) => (
+                        <li key={i} className="text-xs text-muted-foreground flex items-start gap-2">
+                          <span className="text-amber-500 mt-0.5">•</span>{r}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  {/* Suggested new skills */}
+                  {savedContent.aiEvaluation.suggestedNewSkills.length > 0 && (
+                    <div className="rounded-lg border p-4 space-y-2">
+                      <h3 className="font-semibold text-sm flex items-center gap-2">
+                        <Sparkles className="h-4 w-4 text-purple-500" /> Suggested Skills to Add
+                      </h3>
+                      <div className="flex flex-wrap gap-2">
+                        {savedContent.aiEvaluation.suggestedNewSkills.map((s, i) => (
+                          <span key={i} className="px-2 py-0.5 rounded text-xs bg-purple-50 text-purple-700 border border-purple-200 dark:bg-purple-950/30 dark:text-purple-300 dark:border-purple-800">
+                            {s}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
               ) : (
-                <div className="flex flex-wrap gap-2">
-                  {profile.skills.map((skill) => (
-                    <button
-                      key={skill.id}
-                      onClick={() => toggleSkill(skill.id)}
-                      className={`px-3 py-1.5 text-sm rounded-full border transition-colors ${
-                        content.selectedSkills?.includes(skill.id)
-                          ? "border-primary bg-primary text-primary-foreground"
-                          : "border-border hover:bg-muted"
-                      }`}
-                    >
-                      {skill.title}
-                    </button>
-                  ))}
+                <div className="text-center py-12 border-2 border-dashed rounded-lg space-y-2">
+                  <Sparkles className="h-8 w-8 mx-auto text-muted-foreground" />
+                  <p className="text-sm font-medium">No AI evaluation yet</p>
+                  <p className="text-xs text-muted-foreground">
+                    Use the{" "}
+                    <Link href="/dashboard/job-evaluator" className="underline">
+                      Job Evaluator
+                    </Link>{" "}
+                    to generate a tailored resume and AI insights will appear here.
+                  </p>
                 </div>
               )}
             </div>
@@ -408,20 +868,25 @@ export default function ResumeEditor({ resume, profile }: ResumeEditorProps) {
         </div>
       </div>
 
-      {/* Right Side - Preview */}
-      <div className="flex-1 bg-muted/30 overflow-auto p-8">
-        <div className="max-w-[800px] mx-auto">
-          <div className="mb-4 flex justify-end">
-            <Button variant="outline" size="sm">
-              <Download className="h-4 w-4 mr-2" />
-              Download PDF
-            </Button>
-          </div>
+      {/* ── Right Preview ──────────────────────────────────────────────── */}
+      <div className="flex-1 bg-muted/40 overflow-auto print:overflow-visible print:bg-white print:p-0">
+        {/* Toolbar — hidden on print */}
+        <div className="sticky top-0 z-10 bg-muted/80 backdrop-blur-sm border-b px-6 py-2 flex items-center justify-between print:hidden">
+          <span className="text-xs text-muted-foreground font-medium uppercase tracking-wide">Preview</span>
+          <Button variant="outline" size="sm" onClick={handleDownloadPDF}>
+            <Download className="h-4 w-4 mr-1.5" />
+            Download PDF
+          </Button>
+        </div>
+
+        {/* Scale wrapper — centres and shrinks the 794px sheet to fit the pane */}
+        <div className="flex justify-center py-8 print:p-0 print:block">
           <ResumePreview
-            content={content}
-            experiences={selectedExperiences}
-            educations={selectedEducations}
-            skills={selectedSkills}
+            personal={personal}
+            summary={summary}
+            experiences={previewExperiences}
+            educations={previewEducations}
+            skills={previewSkills}
             themeColor={resume.themeColor}
           />
         </div>

--- a/app/dashboard/resumes/[id]/resume-preview.tsx
+++ b/app/dashboard/resumes/[id]/resume-preview.tsx
@@ -1,20 +1,46 @@
 "use client";
 
+import { useRef, useEffect, useState } from "react";
 import { format } from "date-fns";
 import { Mail, Phone, MapPin, Globe, Linkedin } from "lucide-react";
 
-interface ResumePreviewProps {
-  content: {
-    personal?: {
-      fullName?: string;
-      email?: string;
-      phone?: string;
-      location?: string;
-      linkedin?: string;
-      website?: string;
-    };
-    summary?: string;
-  };
+// A4 at 96 dpi
+const A4_H = 1123;
+const A4_W = 794;
+const SCALE = 0.82;
+
+// Margin applied at the top of every page (matches @page margin in globals.css)
+const PAGE_MARGIN_TOP = 52;
+const PAGE_MARGIN_X   = 56;
+// Bottom margin so content never touches the very bottom of a page
+const PAGE_MARGIN_BOT = 40;
+
+function stripHtml(html: string): string {
+  if (!html) return "";
+  let text = html.replace(/<[^>]*>/g, " ");
+  text = text
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+  return text.replace(/\s+/g, " ").trim();
+}
+
+interface PersonalInfo {
+  fullName?: string;
+  title?: string;
+  email?: string;
+  phone?: string;
+  location?: string;
+  linkedin?: string;
+  website?: string;
+}
+
+export interface ResumePreviewProps {
+  personal: PersonalInfo;
+  summary: string;
   experiences: Array<{
     id: string;
     title: string;
@@ -33,166 +59,296 @@ interface ResumePreviewProps {
     endDate?: Date | null;
     current: boolean;
   }>;
-  skills: Array<{
-    id: string;
-    title: string;
-  }>;
+  skills: Array<{ id: string; title: string }>;
   themeColor: string;
 }
 
-export default function ResumePreview({
-  content,
-  experiences,
-  educations,
-  skills,
-  themeColor,
-}: ResumePreviewProps) {
-  const personal = content.personal || {};
+function SectionHeading({ color, children }: { color: string; children: React.ReactNode }) {
+  return (
+    <h2 style={{
+      fontSize: 11, fontWeight: 700, color,
+      borderBottom: `2px solid ${color}`,
+      paddingBottom: 3, marginBottom: 8, marginTop: 0,
+      textTransform: "uppercase", letterSpacing: "0.06em",
+    }}>
+      {children}
+    </h2>
+  );
+}
+
+/** Spacer rendered BEFORE a block — fills the bottom of the current page
+ *  AND adds the top margin so content starts with proper spacing on the new page. */
+function PageBreakSpacer({ blockKey, spacers }: { blockKey: string; spacers: Record<string, number> }) {
+  const h = spacers[blockKey];
+  if (!h) return null;
+  return <div aria-hidden style={{ height: h }} />;
+}
+
+export default function ResumePreview(props: ResumePreviewProps) {
+  const { personal, summary, experiences, educations, skills, themeColor } = props;
+
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [contentHeight, setContentHeight] = useState(A4_H);
+  // spacers[blockKey] = px to insert before that block to push it to next page
+  const [spacers, setSpacers] = useState<Record<string, number>>({});
+  const passRef = useRef(0);
+
+  const recalc = () => {
+    const container = measureRef.current;
+    if (!container) return;
+
+    container.getBoundingClientRect(); // flush
+    const containerTop = container.getBoundingClientRect().top;
+    const blocks = container.querySelectorAll<HTMLElement>("[data-block]");
+    const next: Record<string, number> = {};
+
+    blocks.forEach((block) => {
+      const key = block.getAttribute("data-block")!;
+      const rect = block.getBoundingClientRect();
+      const blockTop    = rect.top  - containerTop;
+      const blockHeight = rect.height;
+      if (blockHeight === 0) return;
+
+      // Which A4 page does this block start on?
+      const pageIndex       = Math.floor(blockTop / A4_H);
+      // How much of the current page has already been used?
+      const posInPage       = blockTop - pageIndex * A4_H;
+      // How much room is left on this page (excluding bottom margin)?
+      const usableHeight    = A4_H - PAGE_MARGIN_BOT;
+      const remainingOnPage = usableHeight - posInPage;
+
+      // Does the block overflow onto the next page?
+      if (remainingOnPage < blockHeight) {
+        const fractionOnNext = (blockHeight - remainingOnPage) / blockHeight;
+        if (fractionOnNext >= 0.5) {
+          // Push entire block to next page.
+          // Spacer = gap to end of page + top margin of new page
+          next[key] = (A4_H - posInPage - pageIndex * 0) + PAGE_MARGIN_TOP;
+        }
+      }
+    });
+
+    setTimeout(() => setSpacers(next), 0);
+  };
+
+  // Pass 1 — on content change
+  useEffect(() => {
+    passRef.current = 0;
+    recalc();
+  }, [personal, summary, experiences, educations, skills, themeColor]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Pass 2 — once after spacers are applied (cascading shifts)
+  useEffect(() => {
+    if (passRef.current >= 1) return;
+    passRef.current += 1;
+    recalc();
+  }, [spacers]);
+
+  // Track total height via ResizeObserver
+  useEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => {
+      if (measureRef.current) setContentHeight(measureRef.current.scrollHeight);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const pageCount  = Math.ceil(contentHeight / A4_H);
+  const GAP        = 20; // gap between page cards in the preview
+  const scaledW    = A4_W  * SCALE;
+  const scaledH    = (pageCount * A4_H + (pageCount - 1) * GAP) * SCALE;
+
+  const contentProps = { ...props, spacers };
 
   return (
-    <div
-      className="bg-white shadow-lg rounded-sm"
-      style={{ aspectRatio: "8.5/11", minHeight: "1056px" }}
-    >
-      <div className="p-8 h-full">
-        {/* Header / Personal Info */}
-        <header className="mb-6">
-          <h1
-            className="text-3xl font-bold mb-2"
-            style={{ color: themeColor }}
-          >
-            {personal.fullName || "Your Name"}
-          </h1>
+    <>
+      {/* ── Hidden measurement div — full 794px, invisible ───────────── */}
+      <div
+        ref={measureRef}
+        aria-hidden
+        style={{
+          position: "fixed",
+          top: 0, left: -9999,
+          width: A4_W,
+          visibility: "hidden",
+          pointerEvents: "none",
+          fontFamily: "Georgia,'Times New Roman',serif",
+          fontSize: 13,
+        }}
+      >
+        <ResumeContent {...contentProps} />
+      </div>
 
-          <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-600">
-            {personal.email && (
-              <span className="flex items-center gap-1">
-                <Mail className="h-3.5 w-3.5" />
-                {personal.email}
-              </span>
-            )}
-            {personal.phone && (
-              <span className="flex items-center gap-1">
-                <Phone className="h-3.5 w-3.5" />
-                {personal.phone}
-              </span>
-            )}
-            {personal.location && (
-              <span className="flex items-center gap-1">
-                <MapPin className="h-3.5 w-3.5" />
-                {personal.location}
-              </span>
-            )}
-            {personal.linkedin && (
-              <span className="flex items-center gap-1">
-                <Linkedin className="h-3.5 w-3.5" />
-                {personal.linkedin}
-              </span>
-            )}
-            {personal.website && (
-              <span className="flex items-center gap-1">
-                <Globe className="h-3.5 w-3.5" />
-                {personal.website}
-              </span>
-            )}
+      {/* ── On-screen scaled preview ─────────────────────────────────── */}
+      <div className="print:hidden relative" style={{ width: scaledW, height: scaledH, flexShrink: 0 }}>
+        <div style={{ transformOrigin: "top left", transform: `scale(${SCALE})`, width: A4_W, position: "absolute", top: 0, left: 0 }}>
+
+          {/* Page count badge */}
+          <div style={{ position: "absolute", top: -22, right: 0, fontSize: 11, color: "#9ca3af", fontFamily: "Arial,sans-serif" }}>
+            {pageCount} page{pageCount !== 1 ? "s" : ""}
           </div>
-        </header>
 
-        {/* Summary */}
-        {content.summary && (
-          <section className="mb-6">
-            <h2
-              className="text-lg font-semibold mb-2 pb-1 border-b-2"
-              style={{ borderColor: themeColor, color: themeColor }}
-            >
-              Summary
-            </h2>
-            <p className="text-sm text-gray-700 leading-relaxed">
-              {content.summary}
+          {/* Single continuous white sheet — always light mode */}
+          <div style={{ width: A4_W, backgroundColor: "#fff", color: "#111827", colorScheme: "light", boxShadow: "0 4px 32px rgba(0,0,0,0.14)" }}>
+            <ResumeContent {...contentProps} />
+          </div>
+
+          {/* Visual page-break lines overlaid on the sheet */}
+          {Array.from({ length: pageCount - 1 }, (_, i) => (
+            <div
+              key={i}
+              style={{
+                position: "absolute",
+                top: (i + 1) * A4_H - 1,
+                left: 0, right: 0,
+                height: 3,
+                background: "#6366f1",
+                opacity: 0.35,
+                pointerEvents: "none",
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* ── Print-only — browser adds @page margins automatically ────── */}
+      <div
+        className="hidden print:block"
+        style={{
+          width: A4_W,
+          fontFamily: "Georgia,'Times New Roman',serif",
+          fontSize: 13,
+          color: "#111827",
+        }}
+      >
+        <ResumeContent {...contentProps} printMode />
+      </div>
+    </>
+  );
+}
+
+// ─── Content ────────────────────────────────────────────────────────────────
+
+interface ResumeContentProps extends ResumePreviewProps {
+  spacers: Record<string, number>;
+  printMode?: boolean;
+}
+
+function ResumeContent({ personal, summary, experiences, educations, skills, themeColor, spacers, printMode }: ResumeContentProps) {
+  return (
+    // Explicit light-mode colors so dark OS theme / .dark class never bleeds into the PDF
+    <div style={{ padding: `${PAGE_MARGIN_TOP}px ${PAGE_MARGIN_X}px ${PAGE_MARGIN_BOT}px`, backgroundColor: "#ffffff", color: "#111827", colorScheme: "light" }}>
+
+      {/* ── Header ─────────────────────────────────────────────────────── */}
+      <header style={{ marginBottom: 18, borderBottom: `3px solid ${themeColor}`, paddingBottom: 14 }}>
+        <h1 style={{ fontSize: 28, fontWeight: 700, color: themeColor, margin: 0, lineHeight: 1.2, fontFamily: "Georgia,serif" }}>
+          {personal.fullName || "Your Name"}
+        </h1>
+        {personal.title && (
+          <p style={{ fontSize: 13, color: "#374151", margin: "4px 0 0", fontStyle: "italic", fontFamily: "Georgia,serif" }}>
+            {personal.title}
+          </p>
+        )}
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "4px 16px", marginTop: 8, fontSize: 11, color: "#4b5563", fontFamily: "Arial,sans-serif" }}>
+          {personal.email    && <span style={{ display: "flex", alignItems: "center", gap: 4 }}><Mail     style={{ width: 11, height: 11, color: "#4b5563", flexShrink: 0 }} />{personal.email}</span>}
+          {personal.phone    && <span style={{ display: "flex", alignItems: "center", gap: 4 }}><Phone    style={{ width: 11, height: 11, color: "#4b5563", flexShrink: 0 }} />{personal.phone}</span>}
+          {personal.location && <span style={{ display: "flex", alignItems: "center", gap: 4 }}><MapPin   style={{ width: 11, height: 11, color: "#4b5563", flexShrink: 0 }} />{personal.location}</span>}
+          {personal.linkedin && <span style={{ display: "flex", alignItems: "center", gap: 4 }}><Linkedin style={{ width: 11, height: 11, color: "#4b5563", flexShrink: 0 }} />{personal.linkedin}</span>}
+          {personal.website  && <span style={{ display: "flex", alignItems: "center", gap: 4 }}><Globe    style={{ width: 11, height: 11, color: "#4b5563", flexShrink: 0 }} />{personal.website}</span>}
+        </div>
+      </header>
+
+      {/* ── Summary ────────────────────────────────────────────────────── */}
+      {summary && (
+        <>
+          <PageBreakSpacer blockKey="summary" spacers={spacers} />
+          <section data-block="summary" style={{ marginBottom: 16, breakInside: "avoid" }}>
+            <SectionHeading color={themeColor}>Summary</SectionHeading>
+            <p style={{ fontSize: 11.5, color: "#374151", lineHeight: 1.65, margin: 0, fontFamily: "Arial,sans-serif" }}>
+              {stripHtml(summary)}
             </p>
           </section>
-        )}
+        </>
+      )}
 
-        {/* Experience */}
-        {experiences.length > 0 && (
-          <section className="mb-6">
-            <h2
-              className="text-lg font-semibold mb-3 pb-1 border-b-2"
-              style={{ borderColor: themeColor, color: themeColor }}
-            >
-              Professional Experience
-            </h2>
-            <div className="space-y-4">
-              {experiences.map((exp) => (
-                <div key={exp.id}>
-                  <div className="flex justify-between items-start mb-1">
+      {/* ── Experience ─────────────────────────────────────────────────── */}
+      {experiences.length > 0 && (
+        <section style={{ marginBottom: 16 }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+            {experiences.map((exp, idx) => (
+              <div key={exp.id}>
+                <PageBreakSpacer blockKey={`exp-${exp.id}`} spacers={spacers} />
+                <div data-block={`exp-${exp.id}`} style={{ breakInside: "avoid" }}>
+                  {idx === 0 && <SectionHeading color={themeColor}>Professional Experience</SectionHeading>}
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 8 }}>
                     <div>
-                      <h3 className="font-semibold text-gray-900">{exp.title}</h3>
-                      <p className="text-sm text-gray-600">
+                      <p style={{ fontSize: 12.5, fontWeight: 700, color: "#111827", margin: 0, fontFamily: "Arial,sans-serif" }}>{exp.title}</p>
+                      <p style={{ fontSize: 11, color: "#6b7280", margin: "2px 0 0", fontFamily: "Arial,sans-serif" }}>
                         {exp.companyName}{exp.companyName && exp.location ? " · " : ""}{exp.location}
                       </p>
                     </div>
-                    <span className="text-sm text-gray-500 whitespace-nowrap">
-                      {format(new Date(exp.startDate), "MMM yyyy")} -{" "}
+                    <span style={{ fontSize: 10.5, color: "#9ca3af", whiteSpace: "nowrap", flexShrink: 0, fontFamily: "Arial,sans-serif" }}>
+                      {format(new Date(exp.startDate), "MMM yyyy")} –{" "}
                       {exp.current ? "Present" : exp.endDate ? format(new Date(exp.endDate), "MMM yyyy") : "Present"}
                     </span>
                   </div>
-                  <p className="text-sm text-gray-700 mt-1">{exp.description}</p>
+                  <p style={{ fontSize: 11, color: "#374151", lineHeight: 1.6, margin: "4px 0 0", fontFamily: "Arial,sans-serif" }}>
+                    {stripHtml(exp.description)}
+                  </p>
                 </div>
-              ))}
-            </div>
-          </section>
-        )}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
-        {/* Education */}
-        {educations.length > 0 && (
-          <section className="mb-6">
-            <h2
-              className="text-lg font-semibold mb-3 pb-1 border-b-2"
-              style={{ borderColor: themeColor, color: themeColor }}
-            >
-              Education
-            </h2>
-            <div className="space-y-3">
-              {educations.map((edu) => (
-                <div key={edu.id} className="flex justify-between items-start">
-                  <div>
-                    <h3 className="font-semibold text-gray-900">{edu.degree}</h3>
-                    <p className="text-sm text-gray-600">{edu.institution}</p>
+      {/* ── Education ──────────────────────────────────────────────────── */}
+      {educations.length > 0 && (
+        <section style={{ marginBottom: 16 }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {educations.map((edu, idx) => (
+              <div key={edu.id}>
+                <PageBreakSpacer blockKey={`edu-${edu.id}`} spacers={spacers} />
+                <div data-block={`edu-${edu.id}`} style={{ breakInside: "avoid" }}>
+                  {idx === 0 && <SectionHeading color={themeColor}>Education</SectionHeading>}
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 8 }}>
+                    <div>
+                      <p style={{ fontSize: 12.5, fontWeight: 700, color: "#111827", margin: 0, fontFamily: "Arial,sans-serif" }}>{edu.degree}</p>
+                      <p style={{ fontSize: 11, color: "#6b7280", margin: "2px 0 0", fontFamily: "Arial,sans-serif" }}>{edu.institution}</p>
+                    </div>
+                    <span style={{ fontSize: 10.5, color: "#9ca3af", whiteSpace: "nowrap", flexShrink: 0, fontFamily: "Arial,sans-serif" }}>
+                      {format(new Date(edu.startDate), "MMM yyyy")} –{" "}
+                      {edu.current ? "Present" : edu.endDate ? format(new Date(edu.endDate), "MMM yyyy") : "Present"}
+                    </span>
                   </div>
-                  <span className="text-sm text-gray-500 whitespace-nowrap">
-                    {format(new Date(edu.startDate), "MMM yyyy")} -{" "}
-                    {edu.current ? "Present" : edu.endDate ? format(new Date(edu.endDate), "MMM yyyy") : "Present"}
-                  </span>
                 </div>
-              ))}
-            </div>
-          </section>
-        )}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
-        {/* Skills */}
-        {skills.length > 0 && (
-          <section>
-            <h2
-              className="text-lg font-semibold mb-3 pb-1 border-b-2"
-              style={{ borderColor: themeColor, color: themeColor }}
-            >
-              Skills
-            </h2>
-            <div className="flex flex-wrap gap-2">
+      {/* ── Skills ─────────────────────────────────────────────────────── */}
+      {skills.length > 0 && (
+        <>
+          <PageBreakSpacer blockKey="skills" spacers={spacers} />
+          <section data-block="skills" style={{ breakInside: "avoid" }}>
+            <SectionHeading color={themeColor}>Skills</SectionHeading>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 5 }}>
               {skills.map((skill) => (
-                <span
-                  key={skill.id}
-                  className="px-2.5 py-1 text-sm rounded-md text-white"
-                  style={{ backgroundColor: themeColor }}
-                >
+                <span key={skill.id} style={{ padding: "3px 9px", fontSize: 10.5, fontWeight: 600, borderRadius: 3, color: "#fff", backgroundColor: themeColor, fontFamily: "Arial,sans-serif" }}>
                   {skill.title}
                 </span>
               ))}
             </div>
           </section>
-        )}
-      </div>
+        </>
+      )}
+
+      {/* Bottom padding so last item never touches the page-break line */}
+      {!printMode && <div style={{ height: PAGE_MARGIN_BOT }} />}
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -173,3 +173,41 @@
 .tiptap u {
   text-decoration: underline;
 }
+
+/* ── Print ───────────────────────────────────────────────────────────────── */
+@media print {
+  @page {
+    size: A4;
+    margin: 32px 32px;
+  }
+
+  /* Force light mode regardless of OS/browser dark-mode setting */
+  html,
+  html.dark {
+    color-scheme: light;
+  }
+
+  html,
+  body {
+    width: 794px;
+    background: white !important;
+    color: #111827 !important;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  /* Strip dark-mode CSS variable overrides so all resume text prints dark */
+  html.dark,
+  html.dark body,
+  html.dark * {
+    --background: #ffffff;
+    --foreground: #111827;
+    color: inherit;
+  }
+
+  /* Force all SVG icons to use their explicit inline color, not dark-mode currentColor */
+  svg {
+    color: currentColor !important;
+    stroke: currentColor !important;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,22 +8,22 @@ import Projects from "@/components/projects";
 import SectionDivider from "@/components/section-divider";
 import Skills from "@/components/skills";
 import ActiveSectionProvider from "@/providers/active-section-provider";
+import { getPublicProfile } from "@/actions/profile.action";
 import { getProjects } from "@/actions/project.action";
 import { getSkills } from "@/actions/skill.action";
 import { getExperiences } from "@/actions/experience.action";
 import { getEducations } from "@/actions/education.action";
-import { getPublicProfile } from "@/actions/profile.action";
 
 export default async function Home() {
-  const [dbProjects, dbSkills, dbExperiences, dbEducations, profile] = await Promise.all([
+  const [profile, projects, dbSkills, experiences, educations] = await Promise.all([
+    getPublicProfile(),
     getProjects(),
     getSkills(),
     getExperiences(),
     getEducations(),
-    getPublicProfile(),
   ]);
 
-  const projects = dbProjects.length > 0 ? dbProjects : [];
+  // Map skills to titles for the Skills component
   const skills = dbSkills.map((s) => s.title);
 
   return (
@@ -35,8 +35,8 @@ export default async function Home() {
         <About profile={profile} />
         <Projects projects={projects} />
         <Skills skills={skills} />
-        <Experience experiences={dbExperiences} />
-        <Education educations={dbEducations} />
+        <Experience experiences={experiences} />
+        <Education educations={educations} />
         <Footer />
       </main>
     </ActiveSectionProvider>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Briefcase, Layers, Star, FileText, GraduationCap, User } from "lucide-react";
+import { Briefcase, Layers, Star, FileText, GraduationCap, User, Bot } from "lucide-react";
 import Link from "next/link";
 
 import {
@@ -42,6 +42,11 @@ const items = [
     title: "Resumes",
     url: "/dashboard/resumes",
     icon: FileText,
+  },
+  {
+    title: "Job Evaluator",
+    url: "/dashboard/job-evaluator",
+    icon: Bot,
   },
 ];
 

--- a/components/theme-control.tsx
+++ b/components/theme-control.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import React from "react";
 import { BsMoon, BsSun } from "react-icons/bs";
 
 import { useTheme } from "@/providers/theme-provider";
@@ -10,7 +9,7 @@ const ThemeControl = () => {
 
   return (
     <button
-      className="fixed bottom-5 right-5 bg-white w-[3rem] h-[3rem] bg-opacity-80 backdrop-blur-[0.5rem] border border-white border-opacity-40 shadow-2xl rounded-full flex items-center justify-center hover:scale-[1.15] active:scale-105 transition-all dark:bg-gray-950"
+      className="fixed bottom-5 right-5 bg-white w-[3rem] h-[3rem] bg-opacity-80 backdrop-blur-[0.5rem] border border-white border-opacity-40 shadow-2xl rounded-full flex items-center justify-center hover:scale-[1.15] active:scale-105 transition-all dark:bg-gray-950 print:hidden"
       onClick={toggleTheme}
     >
       {theme === "light" ? <BsSun /> : <BsMoon />}

--- a/lib/ai-prompts.ts
+++ b/lib/ai-prompts.ts
@@ -1,0 +1,140 @@
+export function buildSystemPrompt(): string {
+  return `You are an expert career advisor and resume consultant. You will be given a job description and a candidate's full profile data. Your job is to:
+
+1. Evaluate the candidate's fit for the role
+2. Suggest a tailored resume using ONLY their existing data (selecting the most relevant items by their IDs)
+3. Identify skill gaps and suggest new skills
+
+You MUST respond with valid JSON matching this exact schema:
+{
+  "evaluation": {
+    "matchPercentage": <number 0-100>,
+    "overallAssessment": "<2-3 sentence summary>",
+    "strengths": ["<strength 1>", "<strength 2>", ...],
+    "gaps": ["<gap 1>", "<gap 2>", ...],
+    "recommendations": ["<recommendation 1>", ...]
+  },
+  "suggestedResume": {
+    "resumeTitle": "<suggested resume title for this job>",
+    "summary": "<tailored professional summary written in first person>",
+    "selectedExperienceIds": ["<id1>", "<id2>"],
+    "selectedEducationIds": ["<id1>"],
+    "selectedSkillIds": ["<id1>", "<id2>", ...]
+  },
+  "suggestedNewSkills": ["<skill name 1>", "<skill name 2>", ...]
+}
+
+IMPORTANT RULES:
+- For selectedExperienceIds, selectedEducationIds, and selectedSkillIds, ONLY use the exact IDs provided in the candidate data
+- Order selected items by relevance to the job (most relevant first)
+- suggestedNewSkills should ONLY include skills NOT already in the candidate's profile
+- The summary should be tailored specifically to the job description, written in first person, referencing the candidate's actual experience
+- Be honest and realistic about the match percentage - do not inflate it
+- Respond with ONLY the JSON object, no markdown code fences, no explanation, no extra text`;
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (!text || text.length <= maxLength) return text || "";
+  return text.substring(0, maxLength) + "...";
+}
+
+function formatDate(date: Date | string | null | undefined): string {
+  if (!date) return "N/A";
+  const d = new Date(date);
+  return d.toLocaleDateString("en-US", { year: "numeric", month: "short" });
+}
+
+export function buildUserPrompt(
+  jobDescription: string,
+  profileData: {
+    profile: {
+      fullName: string;
+      email: string;
+      title?: string | null;
+      location?: string | null;
+      yearsOfExp?: number | null;
+      summary?: string | null;
+    };
+    experiences: Array<{
+      id: string;
+      title: string;
+      companyName?: string | null;
+      location?: string | null;
+      locationType?: string | null;
+      employmentType?: string | null;
+      description: string;
+      startDate: Date | string;
+      endDate?: Date | string | null;
+      current: boolean;
+    }>;
+    educations: Array<{
+      id: string;
+      institution: string;
+      degree: string;
+      description?: string | null;
+      startDate: Date | string;
+      endDate?: Date | string | null;
+      current: boolean;
+    }>;
+    skills: Array<{
+      id: string;
+      title: string;
+    }>;
+    projects: Array<{
+      id: string;
+      title: string;
+      description: string;
+      tags: string[];
+    }>;
+  }
+): string {
+  const { profile, experiences, educations, skills, projects } = profileData;
+
+  const experiencesList = experiences
+    .map(
+      (e) =>
+        `- ID: "${e.id}" | ${e.title} at ${e.companyName || "N/A"} (${formatDate(e.startDate)} - ${e.current ? "Present" : formatDate(e.endDate)}) | ${e.employmentType || ""} ${e.locationType || ""}\n  Description: ${truncate(e.description, 500)}`
+    )
+    .join("\n");
+
+  const educationsList = educations
+    .map(
+      (e) =>
+        `- ID: "${e.id}" | ${e.degree} at ${e.institution} (${formatDate(e.startDate)} - ${e.current ? "Present" : formatDate(e.endDate)})${e.description ? `\n  ${truncate(e.description, 300)}` : ""}`
+    )
+    .join("\n");
+
+  const skillsList = skills.map((s) => `- ID: "${s.id}" | ${s.title}`).join("\n");
+
+  const projectsList = projects
+    .map(
+      (p) =>
+        `- ${p.title}: ${truncate(p.description, 300)} | Tags: ${p.tags.join(", ")}`
+    )
+    .join("\n");
+
+  return `## JOB DESCRIPTION
+${jobDescription}
+
+## CANDIDATE PROFILE
+Name: ${profile.fullName}
+Title: ${profile.title || "Not specified"}
+Email: ${profile.email}
+Location: ${profile.location || "Not specified"}
+Years of Experience: ${profile.yearsOfExp || "Not specified"}
+Current Summary: ${profile.summary ? truncate(profile.summary, 500) : "None"}
+
+## EXPERIENCES
+${experiencesList || "No experiences listed."}
+
+## EDUCATION
+${educationsList || "No education listed."}
+
+## SKILLS
+${skillsList || "No skills listed."}
+
+## PROJECTS
+${projectsList || "No projects listed."}
+
+Analyze this candidate's fit for the job and provide your structured evaluation as JSON.`;
+}

--- a/lib/ai-providers.ts
+++ b/lib/ai-providers.ts
@@ -1,0 +1,60 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+
+export const AI_PROVIDERS = [
+  { label: "OpenAI (GPT-4o)", value: "openai" },
+  { label: "Claude (Anthropic)", value: "anthropic" },
+  { label: "Gemini (Google)", value: "google" },
+] as const;
+
+export type AIProviderKey = (typeof AI_PROVIDERS)[number]["value"];
+
+// OpenRouter model IDs for each provider
+// Used when OPENAI_API_KEY is an OpenRouter key (starts with "sk-or-")
+const OPENROUTER_MODELS: Record<AIProviderKey, string> = {
+  openai: "openai/gpt-4o-mini",          // cheaper than gpt-4o
+  anthropic: "anthropic/claude-3-haiku", // cheapest Claude
+  google: "google/gemini-2.0-flash-001", // fast & cheap
+};
+
+function getOpenRouter(key: string) {
+  return createOpenAI({
+    apiKey: key,
+    baseURL: "https://openrouter.ai/api/v1",
+  });
+}
+
+export function getAIModel(provider: AIProviderKey) {
+  const openaiKey = process.env.OPENAI_API_KEY ?? "";
+  const anthropicKey = process.env.ANTHROPIC_API_KEY ?? "";
+  const googleKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? "";
+  const isOpenRouter = openaiKey.startsWith("sk-or-");
+
+  switch (provider) {
+    case "openai": {
+      if (openaiKey && !isOpenRouter)
+        return createOpenAI({ apiKey: openaiKey })("gpt-4o");
+      if (isOpenRouter)
+        return getOpenRouter(openaiKey)(OPENROUTER_MODELS.openai);
+      throw new Error("OPENAI_API_KEY is not configured.");
+    }
+    case "anthropic": {
+      if (anthropicKey)
+        return createAnthropic({ apiKey: anthropicKey })("claude-sonnet-4-20250514");
+      if (isOpenRouter)
+        return getOpenRouter(openaiKey)(OPENROUTER_MODELS.anthropic);
+      throw new Error("ANTHROPIC_API_KEY is not configured.");
+    }
+    case "google": {
+      // Prefer OpenRouter for Gemini (direct free quota exhausts quickly)
+      if (isOpenRouter)
+        return getOpenRouter(openaiKey)(OPENROUTER_MODELS.google);
+      if (googleKey)
+        return createGoogleGenerativeAI({ apiKey: googleKey })("gemini-2.0-flash");
+      throw new Error("GOOGLE_GENERATIVE_AI_API_KEY is not configured.");
+    }
+    default:
+      throw new Error(`Unknown AI provider: ${provider}`);
+  }
+}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -89,6 +89,36 @@ export const profileSchema = z.object({
 
 export type TProfile = z.infer<typeof profileSchema>;
 
+// AI Job Evaluation validation
+export const jobEvaluationFormSchema = z.object({
+  jobDescription: z
+    .string()
+    .min(50, "Job description must be at least 50 characters"),
+  provider: z.enum(["openai", "anthropic", "google"]),
+});
+
+export type TJobEvaluationForm = z.infer<typeof jobEvaluationFormSchema>;
+
+export const aiEvaluationResponseSchema = z.object({
+  evaluation: z.object({
+    matchPercentage: z.number().min(0).max(100),
+    overallAssessment: z.string(),
+    strengths: z.array(z.string()),
+    gaps: z.array(z.string()),
+    recommendations: z.array(z.string()),
+  }),
+  suggestedResume: z.object({
+    resumeTitle: z.string(),
+    summary: z.string(),
+    selectedExperienceIds: z.array(z.string()),
+    selectedEducationIds: z.array(z.string()),
+    selectedSkillIds: z.array(z.string()),
+  }),
+  suggestedNewSkills: z.array(z.string()),
+});
+
+export type TAIEvaluationResponse = z.infer<typeof aiEvaluationResponseSchema>;
+
 // Common validation
 export const ObjectIdSchema = z.string().regex(/^[a-fA-F0-9]{24}$/, {
   message: "Invalid ID format",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.44",
+        "@ai-sdk/google": "^3.0.29",
+        "@ai-sdk/openai": "^3.0.29",
+        "@ai-sdk/react": "^3.0.88",
         "@clerk/nextjs": "^6.36.8",
         "@hookform/resolvers": "^5.2.2",
         "@prisma/client": "^6.19.2",
@@ -69,14 +73,30 @@
         "typescript": "^5"
       }
     },
-    "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.18.tgz",
-      "integrity": "sha512-WlJ7UkBDYgv+5q9UpGZfbnPrrW3KVnY96lRLaXs8nXy7Ea3QTWXf4Jw43jFzMSVkH4Zhhf0s9ExmG+CiyEBY5A==",
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.44",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.44.tgz",
+      "integrity": "sha512-ke1NldgohWJ7sWLqm9Um9TVIOrtg8Y8AecWeB6PgaLt+paTPisAsyNfe8FNOVusuv58ugLBqY/78AkhUmbjXHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.4",
-        "@ai-sdk/provider-utils": "4.0.8",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.46",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.46.tgz",
+      "integrity": "sha512-zH1UbNRjG5woOXXFOrVCZraqZuFTtmPvLardMGcgLkzpxKV0U3tAGoyWKSZ862H+eBJfI/Hf2yj/zzGJcCkycg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15",
         "@vercel/oidc": "3.1.0"
       },
       "engines": {
@@ -86,10 +106,42 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.29",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.29.tgz",
+      "integrity": "sha512-x0hcU10AA+i1ZUQHloGD5qXWsB+Y8qnxlmFUef6Ly4rB53MGVbQExkI9nOKiCO3mu2TGiiNoQMeKWSeQVLfRUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.29",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.29.tgz",
+      "integrity": "sha512-ugVTIVpuSLKTjzSPe1F1DWiblJT/lwrrHx0OZEKjpMk/EYP6j6VD/F7SJqM1dsqOJryeBCJWFbUzLNqc99PrMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.4.tgz",
-      "integrity": "sha512-5KXyBOSEX+l67elrEa+wqo/LSsSTtrPj9Uoh3zMbe/ceQX4ucHI3b9nUEfNkGF3Ry1svv90widAt+aiKdIJasQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -99,12 +151,12 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.8.tgz",
-      "integrity": "sha512-ns9gN7MmpI8vTRandzgz+KK/zNMLzhrriiKECMt4euLtQFSBgNfydtagPOX4j4pS1/3KvHF6RivhT3gNQgBZsg==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
+      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.4",
+        "@ai-sdk/provider": "3.0.8",
         "@standard-schema/spec": "^1.1.0",
         "eventsource-parser": "^3.0.6"
       },
@@ -113,6 +165,24 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.88",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.88.tgz",
+      "integrity": "sha512-fsUsDP0S+AAmxwgzxYhn9MQKmnAg7AttV3yrSw3bvI5MVfl0LBD3ViRuGNqY8S1DkkDfEF4BLom/nkbD1zY4bQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.15",
+        "ai": "6.0.86",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2112,6 +2182,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4954,7 +5025,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.18.0.tgz",
       "integrity": "sha512-4HNTzkRGP+9YL8ccCRHFwH469GN6/NKefFAzYZjh2l8JOrPgiYqIlu7Tc+q9w1L5m8f6sC5DBQfGOsgWxuM3GQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5768,14 +5838,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.44",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.44.tgz",
-      "integrity": "sha512-fOyssuNfSB3i3ODuDeLaWambfJY+gE3LRHQf4nmWEPDrQhfiB+fcpVMVi77LbFRBfoG/h5BrmX0heVqz4Hl7ug==",
+      "version": "6.0.86",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.86.tgz",
+      "integrity": "sha512-U2W2LBCHA/pr0Ui7vmmsjBiLEzBbZF3yVHNy7Rbzn7IX+SvoQPFM5rN74hhfVzZoE8zBuGD4nLLk+j0elGacvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.18",
-        "@ai-sdk/provider": "3.0.4",
-        "@ai-sdk/provider-utils": "4.0.8",
+        "@ai-sdk/gateway": "3.0.46",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {
@@ -11050,6 +11120,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-inflate": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "seed": "npx tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.44",
+    "@ai-sdk/google": "^3.0.29",
+    "@ai-sdk/openai": "^3.0.29",
+    "@ai-sdk/react": "^3.0.88",
     "@clerk/nextjs": "^6.36.8",
     "@hookform/resolvers": "^5.2.2",
     "@prisma/client": "^6.19.2",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,8 +1,5 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
-// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
+// Single-user portfolio schema - FlowCV style
+// All entities are top-level and belong to the single authenticated user
 
 generator client {
   provider = "prisma-client-js"
@@ -14,24 +11,42 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Project {
-  id          String   @id @default(auto()) @map("_id") @db.ObjectId
-  title       String
-  description String
-  tags        String[]
+//////////////////////////////////////
+// PERSONAL INFO (SINGLE ENTRY ONLY)
+//////////////////////////////////////
 
-  imageUrl  String?
-  liveUrl   String?
-  githubUrl String?
+model Profile {
+  id String @id @default(auto()) @map("_id") @db.ObjectId
 
-  order Int?
+  // Basic info
+  fullName String
+  email    String
+  phone    String?
+  location String?
 
-  userProfileId String?      @db.ObjectId
-  userProfile   UserProfile? @relation(fields: [userProfileId], references: [id])
+  // Professional summary
+  title      String? // e.g., "Full Stack Engineer"
+  summary    String? // Brief professional summary
+  yearsOfExp Int?    // Years of experience
+
+  // Rich text sections for homepage
+  introText String? // Rich text intro paragraph
+  aboutText String? // Rich text about content
+
+  // Media & Links
+  profileImageUrl String?
+  cvUrl           String? // Link to downloadable CV/PDF
+  linkedinUrl     String?
+  githubUrl       String?
+  websiteUrl      String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+//////////////////////////////////////
+// TOP-LEVEL ENTITIES (NO RELATIONS)
+//////////////////////////////////////
 
 model Experience {
   id String @id @default(auto()) @map("_id") @db.ObjectId
@@ -42,33 +57,21 @@ model Experience {
   locationType   String? // Remote / Onsite / Hybrid
   employmentType String? // Full-time / Part-time / Contract / Intern
 
-  description    String
+  description    String // Rich text
   icon           String?
   companyLogoUrl String?
 
   startDate DateTime
   endDate   DateTime?
-  current   Boolean   @default(false)
+  current   Boolean  @default(false)
 
-  order Int?
-
-  userProfileId String?      @db.ObjectId
-  userProfile   UserProfile? @relation(fields: [userProfileId], references: [id])
+  order Int @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-}
 
-model Skill {
-  id    String @id @default(auto()) @map("_id") @db.ObjectId
-  title String @unique
-  order Int?
-
-  userProfileId String?      @db.ObjectId
-  userProfile   UserProfile? @relation(fields: [userProfileId], references: [id])
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  @@index([startDate])
+  @@index([order])
 }
 
 model Education {
@@ -76,66 +79,80 @@ model Education {
   institution String
   degree      String
 
-  startDate DateTime
-  endDate   DateTime?
-  current   Boolean   @default(false)
+  startDate   DateTime
+  endDate     DateTime?
+  current     Boolean  @default(false)
+  description String? // Optional field/major description
 
-  description String?
-  order       Int?
-
-  userProfileId String?      @db.ObjectId
-  userProfile   UserProfile? @relation(fields: [userProfileId], references: [id])
+  order Int @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([startDate])
+  @@index([order])
 }
 
-model UserProfile {
+model Skill {
   id       String  @id @default(auto()) @map("_id") @db.ObjectId
-  userId   String  @unique
-  fullName String
-  email    String
-  phone    String?
-  summary  String?
+  title    String  @unique // Globally unique since single user
+  category String? // e.g., "Frontend", "Backend", "DevOps"
+  level    Int?    // Optional proficiency level 1-5
 
-  // Intro section fields
-  title          String? // e.g., "Full Stack Engineer"
-  yearsOfExp     Int?    // Years of experience
-  introText      String? // Rich text intro paragraph
-  profileImageUrl String?
-  cvUrl          String?
-  linkedinUrl    String?
-  githubUrl      String?
-
-  // About section fields
-  aboutText      String? // Rich text about content
-
-  // Location
-  location       String?
-
-  experiences Experience[]
-  educations  Education[]
-  skills      Skill[]
-  projects    Project[]
-  resumes     Resume[]
+  order Int @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([order])
+  @@index([category])
 }
+
+model Project {
+  id          String   @id @default(auto()) @map("_id") @db.ObjectId
+  title       String
+  description String // Rich text
+  tags        String[]
+
+  imageUrl  String?
+  liveUrl   String?
+  githubUrl String?
+
+  order Int @default(0)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([order])
+}
+
+//////////////////////////////////////
+// RESUME - REFERENCES IDS ONLY
+//////////////////////////////////////
 
 model Resume {
   id    String @id @default(auto()) @map("_id") @db.ObjectId
   title String
 
-  userProfileId String      @db.ObjectId
-  userProfile   UserProfile @relation(fields: [userProfileId], references: [id])
-
+  // Visual customization
   themeColor String @default("#000000")
   layout     String @default("modern")
 
-  content Json
-  version Int  @default(1)
+  // Content selection - store IDs of what to include
+  // This allows user to pick and choose what goes in each resume
+  experienceIds String[] @db.ObjectId
+  educationIds  String[] @db.ObjectId
+  skillIds      String[] @db.ObjectId
+  projectIds    String[] @db.ObjectId
+
+  // Custom content specific to this resume (optional overrides)
+  // Stores: { personal: {...}, summary: "...", customExperiences: [...], etc. }
+  content Json?
+
+  version Int @default(1)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([createdAt])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -130,6 +130,24 @@ async function main() {
   await prisma.project.deleteMany();
   await prisma.experience.deleteMany();
   await prisma.skill.deleteMany();
+  await prisma.education.deleteMany();
+  await prisma.resume.deleteMany();
+  await prisma.profile.deleteMany();
+
+  // Create profile
+  console.log("👤 Creating profile...");
+  const profile = await prisma.profile.create({
+    data: {
+      fullName: "Zain Alabdeen",
+      email: "zain@example.com",
+      phone: "+1234567890",
+      summary: "Full Stack Developer with expertise in React, Node.js, and cloud technologies",
+      title: "Full Stack Engineer",
+      yearsOfExp: 8,
+      location: "Dubai, UAE",
+    },
+  });
+  console.log(`✅ Created profile: ${profile.fullName}`);
 
   // Seed Projects
   console.log("📦 Seeding projects...");


### PR DESCRIPTION
Resume Builder
- Rewrite resume-preview with smart A4 page-break logic — sections pushed to next page when ≥50% crosses a boundary (two-pass measurement)
- Single continuous white sheet preview with visual page-break indicators
- Fix top margin on page 2+ via spacer = remaining page + PAGE_MARGIN_TOP
- @page CSS margins (32px) so every printed page has proper spacing
- Force light mode on print (colorScheme, color overrides, SVG stroke fix)
- Hide theme toggle button (print:hidden) so it never appears in PDF
- Add Professional Title field to personal section
- AI evaluation tab in resume editor reads cached insights from resume.content

AI Job Evaluator
- New /dashboard/job-evaluator page with multi-provider support
- /api/ai/evaluate-job route using generateText (not streamText) so errors surface before response headers are sent
- lib/ai-providers: detect sk-or- OpenRouter keys and route accordingly
- lib/ai-prompts: structured JSON prompt for match %, strengths, gaps, recommendations, suggested resume IDs, and new skills
- Save full AI response into resume.content.aiEvaluation on resume create
- Open created resume in new tab so evaluator page stays open
- Replace useCompletion with plain fetch + extractJSON (strips ```json fences)

Profile Management
- Allow creating profile when none exists (no redirect on null)
- Add createUserProfile server action
- ProfileForm handles both create and update with correct button label

Schema & Actions
- Refactor Prisma schema to single-user flat models (no Clerk userId fields)
- Resume stores experienceIds[], educationIds[], skillIds[] + content Json
- Remove debug console.log from profile.action.ts
- Fix content: unknown typing with SavedContent cast in resume editor

README
- Full project documentation: objectives, tech stack, data model, AI setup, getting started guide, PDF export instructions, similar projects comparison